### PR TITLE
docs: point website link to MonicaDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Monica 是一个聚合 **Bitwarden** 与 **KeePass** 的本地密码库（Local 
 ### 重要的事：
 Monica Pass的开发者就是一个大啥比，现在他为了偷懒连代码都很少review了，还在群里说“反正ai写的比我好，我还不如ai呢”，大家不要相信这种人开发的软件，一定要好好的做好备份，数据隐私无价！不要把所有数据都放到这一个软件里面
 
-官网入口: https://monica-pass.github.io/Monica/
+官网入口: https://monica-pass.github.io/MonicaDocs/
 
 > Monica for Windows 已归档。历史代码见: [Monica-for-Windows](https://github.com/JoyinJoester/Monica-for-Windows)
 >

--- a/README_EN.md
+++ b/README_EN.md
@@ -35,7 +35,7 @@ It is built around local-first storage and helps you manage passwords, 2FA, secu
 
 This project is AI-assisted. Please build a habit of backing up regularly to avoid data loss. Data privacy is priceless, so do not keep all of your data in a single app.
 
-Website: https://monica-pass.github.io/Monica/
+Website: https://monica-pass.github.io/MonicaDocs/
 
 > Monica for Windows is archived. Historical code: [Monica-for-Windows](https://github.com/JoyinJoester/Monica-for-Windows)
 >

--- a/README_JA.md
+++ b/README_JA.md
@@ -35,7 +35,7 @@ Monica は **Bitwarden** と **KeePass** を統合するローカルパスワー
 
 このプロジェクトは AI を活用して作られています。データ損失を防ぐため、定期的なバックアップを習慣にしてください。データのプライバシーは何にも代えがたいので、重要なデータを1つのアプリだけにまとめないようにしてください。
 
-サイト: https://monica-pass.github.io/Monica/
+サイト: https://monica-pass.github.io/MonicaDocs/
 
 > Monica for Windows はアーカイブ済みです。過去コード: [Monica-for-Windows](https://github.com/JoyinJoester/Monica-for-Windows)
 >

--- a/README_Nya.md
+++ b/README_Nya.md
@@ -42,7 +42,7 @@ Monica 的开发者只是一个会犯懒的大笨蛋铲屎官喵。
 
 他有时候会偷懒，有时候会说「反正 AI 写得比我好」这种很欠揉脑袋的话喵。所以你要答应人家：一定要好好备份喵。数据隐私是无价的小鱼干，不能全都压在一个篮子里喵。
 
-官网入口在这里喵: https://monica-pass.github.io/Monica/
+官网入口在这里喵: https://monica-pass.github.io/MonicaDocs/
 
 > Monica for Windows 已经钻进纸箱里归档了喵。想考古的话看这里喵: [Monica-for-Windows](https://github.com/JoyinJoester/Monica-for-Windows)
 >

--- a/README_RU.md
+++ b/README_RU.md
@@ -35,7 +35,7 @@ Monica — это локальное хранилище паролей, кото
 
 Проект создан с использованием ИИ. Сделайте регулярные резервные копии привычкой, чтобы избежать потери данных. Приватность данных бесценна, поэтому не храните все данные только в одном приложении.
 
-Сайт: https://monica-pass.github.io/Monica/
+Сайт: https://monica-pass.github.io/MonicaDocs/
 
 > Monica for Windows архивирован. Исторический код: [Monica-for-Windows](https://github.com/JoyinJoester/Monica-for-Windows)
 >

--- a/README_VI.md
+++ b/README_VI.md
@@ -35,7 +35,7 @@ Ung dung uu tien luu tru local, giup quan ly mat khau, 2FA, ghi chu bao mat va t
 
 Du an nay co su ho tro cua AI. Hay tap tho quen sao luu du lieu thuong xuyen de tranh mat mat du lieu. Quyen rieng tu du lieu la vo gia, vi vay khong nen de tat ca du lieu cua ban nam trong chi mot ung dung.
 
-Trang web: https://monica-pass.github.io/Monica/
+Trang web: https://monica-pass.github.io/MonicaDocs/
 
 > Monica for Windows da duoc luu tru (archived). Ma nguon lich su: [Monica-for-Windows](https://github.com/JoyinJoester/Monica-for-Windows)
 >


### PR DESCRIPTION
Update the official site entry in all six README language variants from https://monica-pass.github.io/Monica/ to
https://monica-pass.github.io/MonicaDocs/.