### PR TITLE
feat(webdav): add HTTPS certificate verification modes

### DIFF
--- a/Monica for Android/app/build.gradle
+++ b/Monica for Android/app/build.gradle
@@ -366,6 +366,9 @@ dependencies {
     testImplementation libs.junit
     testImplementation libs.kotlin.coroutines.test
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    // HeldCertificate lets the WebDAV TLS tests serve a real self-signed chain
+    // instead of asserting on OkHttp internals. Version pinned to match okhttp.
+    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.12.0'
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core
     androidTestImplementation platform(libs.androidx.compose.bom)

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/MonicaApplication.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/MonicaApplication.kt
@@ -22,6 +22,7 @@ import takagi.ru.monica.utils.AppLauncherIconManager
 import takagi.ru.monica.security.SessionManager
 import takagi.ru.monica.utils.SettingsManager
 import takagi.ru.monica.webdav.WebDavBackoffState
+import takagi.ru.monica.webdav.WebDavTlsSettings
 import takagi.ru.monica.workers.KeePassRemoteUploadWorker
 
 /**
@@ -56,6 +57,8 @@ class MonicaApplication : Application() {
         MdbxDiagLogger.initialize(this)
         syncLauncherEntryPointsWithSettings()
         WebDavBackoffState.attachPersistence(this)
+        // 必须早于任何 WebDAV 客户端构造，否则后台备份会用默认档位建连。
+        WebDavTlsSettings.attachPersistence(this)
         scheduleKeePassRemoteUploadRecovery()
         scheduleAttachmentHousekeeping()
     }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/WebDavBackupScreen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/WebDavBackupScreen.kt
@@ -41,6 +41,7 @@ import takagi.ru.monica.utils.BackupRestoreApplier
 import takagi.ru.monica.utils.RestoreResult
 import takagi.ru.monica.utils.WebDavHelper
 import takagi.ru.monica.utils.AutoBackupManager
+import takagi.ru.monica.webdav.WebDavTlsMode
 import takagi.ru.monica.utils.CustomFieldBackupEntry
 import takagi.ru.monica.data.PasswordEntry
 import takagi.ru.monica.data.CustomField
@@ -200,6 +201,11 @@ fun WebDavBackupScreen(
     var encryptionEnabled by remember { mutableStateOf(false) }
     var encryptionPassword by remember { mutableStateOf("") }
     var encryptionPasswordVisible by remember { mutableStateOf(false) }
+
+    // HTTPS 证书校验档位
+    var tlsMode by remember { mutableStateOf(WebDavTlsMode.DEFAULT) }
+    // 待用户二次确认的放宽档位；null 表示无待确认项
+    var pendingTlsMode by remember { mutableStateOf<WebDavTlsMode?>(null) }
     
     // 选择性备份状态
     var backupPreferences by remember { mutableStateOf(takagi.ru.monica.data.BackupPreferences()) }
@@ -243,6 +249,9 @@ fun WebDavBackupScreen(
         val encryptionConfig = webDavHelper.getEncryptionConfig()
         encryptionEnabled = encryptionConfig.enabled
         encryptionPassword = encryptionConfig.password
+
+        // 加载 HTTPS 证书校验档位
+        tlsMode = webDavHelper.getTlsMode()
         
         // 加载备份偏好设置
         backupPreferences = webDavHelper.getBackupPreferences()
@@ -602,6 +611,28 @@ fun WebDavBackupScreen(
                 }
             }
             }
+
+            // HTTPS 证书校验设置卡片
+            // 未配置时紧跟在「测试连接」下方，便于握手失败的用户就地放宽档位；
+            // 已配置时作为连接级设置继续可见。
+            WebDavTlsModeCard(
+                selectedMode = tlsMode,
+                onModeSelected = { mode ->
+                    if (mode == tlsMode) return@WebDavTlsModeCard
+                    if (mode.isRelaxed) {
+                        // 放宽档位一律需要二次确认
+                        pendingTlsMode = mode
+                    } else {
+                        tlsMode = mode
+                        webDavHelper.setTlsMode(mode)
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.webdav_tls_changed),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            )
             
             // 自动备份设置卡片 (仅在配置成功后显示)
             if (isConfigured) {
@@ -1075,6 +1106,24 @@ fun WebDavBackupScreen(
                 Toast.makeText(
                     context,
                     context.getString(R.string.webdav_fill_from_password_applied),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        )
+    }
+
+    // 放宽证书校验前的二次确认
+    pendingTlsMode?.let { candidate ->
+        WebDavTlsRelaxConfirmDialog(
+            mode = candidate,
+            onDismiss = { pendingTlsMode = null },
+            onConfirm = {
+                pendingTlsMode = null
+                tlsMode = candidate
+                webDavHelper.setTlsMode(candidate)
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.webdav_tls_changed),
                     Toast.LENGTH_SHORT
                 ).show()
             }
@@ -2003,6 +2052,178 @@ private suspend fun loadBackups(
         },
         onFailure = { e ->
             onResult(emptyList(), e.message)
+        }
+    )
+}
+
+/** 档位标题的字符串资源。 */
+@Composable
+private fun tlsModeTitle(mode: WebDavTlsMode): String = stringResource(
+    when (mode) {
+        WebDavTlsMode.SYSTEM_DEFAULT -> R.string.webdav_tls_mode_system_title
+        WebDavTlsMode.ALLOW_SELF_SIGNED -> R.string.webdav_tls_mode_self_signed_title
+        WebDavTlsMode.ALLOW_UNTRUSTED -> R.string.webdav_tls_mode_untrusted_title
+    }
+)
+
+/** 档位说明的字符串资源。 */
+@Composable
+private fun tlsModeDescription(mode: WebDavTlsMode): String = stringResource(
+    when (mode) {
+        WebDavTlsMode.SYSTEM_DEFAULT -> R.string.webdav_tls_mode_system_desc
+        WebDavTlsMode.ALLOW_SELF_SIGNED -> R.string.webdav_tls_mode_self_signed_desc
+        WebDavTlsMode.ALLOW_UNTRUSTED -> R.string.webdav_tls_mode_untrusted_desc
+    }
+)
+
+/** 档位图标；风险递增对应盾牌图标的三种状态。 */
+private fun tlsModeIcon(mode: WebDavTlsMode): ImageVector = when (mode) {
+    WebDavTlsMode.SYSTEM_DEFAULT -> Icons.Default.VerifiedUser
+    WebDavTlsMode.ALLOW_SELF_SIGNED -> Icons.Default.GppMaybe
+    WebDavTlsMode.ALLOW_UNTRUSTED -> Icons.Default.GppBad
+}
+
+/**
+ * HTTPS 证书校验档位选择卡片。
+ *
+ * 复用本页 [RestoreModeOptionCard] 的单选卡片视觉：选中项换用
+ * `secondaryContainer` 背景 + 2dp 强调色描边 + 尾部 RadioButton。
+ * 强调色按风险分级：默认档用 primary，自签名用 tertiary，放行档用 error。
+ */
+@Composable
+private fun WebDavTlsModeCard(
+    selectedMode: WebDavTlsMode,
+    onModeSelected: (WebDavTlsMode) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = stringResource(R.string.webdav_tls_title),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = stringResource(R.string.webdav_tls_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                WebDavTlsMode.entries.forEach { mode ->
+                    RestoreModeOptionCard(
+                        title = tlsModeTitle(mode),
+                        description = tlsModeDescription(mode),
+                        icon = tlsModeIcon(mode),
+                        selected = selectedMode == mode,
+                        accentColor = when (mode) {
+                            WebDavTlsMode.SYSTEM_DEFAULT -> MaterialTheme.colorScheme.primary
+                            WebDavTlsMode.ALLOW_SELF_SIGNED -> MaterialTheme.colorScheme.tertiary
+                            WebDavTlsMode.ALLOW_UNTRUSTED -> MaterialTheme.colorScheme.error
+                        },
+                        onClick = { onModeSelected(mode) },
+                    )
+                }
+            }
+
+            // 仅在偏离平台默认时提示风险，避免对绝大多数用户产生噪音。
+            if (selectedMode.isRelaxed) {
+                Surface(
+                    color = MaterialTheme.colorScheme.errorContainer,
+                    shape = MaterialTheme.shapes.large,
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Text(
+                            text = stringResource(R.string.webdav_tls_relaxed_banner),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 放宽证书校验前的二次确认弹窗。
+ *
+ * 两个放宽档位的风险量级不同，因此文案分开：自签名仍有链校验与主机名校验，
+ * 放行档则完全没有身份认证。确认按钮在放行档上使用 error 色以示警。
+ */
+@Composable
+private fun WebDavTlsRelaxConfirmDialog(
+    mode: WebDavTlsMode,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val isUntrusted = mode == WebDavTlsMode.ALLOW_UNTRUSTED
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = tlsModeIcon(mode),
+                contentDescription = null,
+                tint = if (isUntrusted) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.tertiary
+                },
+            )
+        },
+        title = { Text(stringResource(R.string.webdav_tls_confirm_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = tlsModeTitle(mode),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(
+                        if (isUntrusted) {
+                            R.string.webdav_tls_confirm_untrusted
+                        } else {
+                            R.string.webdav_tls_confirm_self_signed
+                        }
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                colors = if (isUntrusted) {
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                } else {
+                    ButtonDefaults.textButtonColors()
+                }
+            ) {
+                Text(stringResource(R.string.webdav_tls_confirm_accept))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
         }
     )
 }

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/utils/WebDavHelper.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/utils/WebDavHelper.kt
@@ -1197,6 +1197,8 @@ class WebDavHelper(
         securityManager.removeProtectedString(SECURE_KEY_USERNAME)
         securityManager.removeProtectedString(SECURE_KEY_PASSWORD)
         securityManager.removeProtectedString(SECURE_KEY_ENCRYPTION_PASSWORD)
+        // 连接配置被清空后，放宽过的证书校验档位不应残留给下一台服务器。
+        takagi.ru.monica.webdav.WebDavTlsSettings.reset(context)
         serverUrl = ""
         username = ""
         password = ""
@@ -5418,9 +5420,11 @@ class WebDavHelper(
 
     private fun createSardineClient(): Sardine {
         // 通过统一的 Gateway 构造，确保所有请求都经过预置式 Basic 鉴权、
-        // 速率限制与 User-Agent 拦截器链（与 Kazumi webdav_client 一致）。
+        // 速率限制与 User-Agent 拦截器链（与 Kazumi webdav_client 一致），
+        // 并应用用户选择的 HTTPS 证书校验档位。
         return takagi.ru.monica.webdav.WebDavGateway.buildClient(
-            takagi.ru.monica.webdav.WebDavCredentials(username, password)
+            credentials = takagi.ru.monica.webdav.WebDavCredentials(username, password),
+            tlsMode = takagi.ru.monica.webdav.WebDavTlsSettings.currentMode(context)
         )
     }
 
@@ -5760,6 +5764,26 @@ class WebDavHelper(
         enableEncryption = enabled
         encryptionPassword = password
         saveConfig()
+    }
+
+    /**
+     * 当前的 HTTPS 证书校验档位。
+     */
+    fun getTlsMode(): takagi.ru.monica.webdav.WebDavTlsMode =
+        takagi.ru.monica.webdav.WebDavTlsSettings.currentMode(context)
+
+    /**
+     * 切换 HTTPS 证书校验档位。
+     *
+     * 档位影响 OkHttp 客户端的构造，因此已建立的 sardine 实例必须重建，
+     * 否则新档位只会在下次冷启动后生效。
+     */
+    fun setTlsMode(mode: takagi.ru.monica.webdav.WebDavTlsMode) {
+        takagi.ru.monica.webdav.WebDavTlsSettings.setMode(context, mode)
+        if (serverUrl.isNotEmpty()) {
+            sardine = createSardineClient()
+        }
+        android.util.Log.d("WebDavHelper", "TLS verification mode set to $mode")
     }
 
     private fun migrateLegacyConfigIfNeeded(prefs: android.content.SharedPreferences) {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/utils/WebDavKeePassFileSource.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/utils/WebDavKeePassFileSource.kt
@@ -2,11 +2,12 @@ package takagi.ru.monica.utils
 
 import android.content.Context
 import com.thegrizzlylabs.sardineandroid.DavResource
-import com.thegrizzlylabs.sardineandroid.impl.OkHttpSardine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import takagi.ru.monica.data.KeepassRemoteSource
 import takagi.ru.monica.security.SecurityManager
+import takagi.ru.monica.webdav.WebDavCredentials
+import takagi.ru.monica.webdav.WebDavGateway
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -28,11 +29,10 @@ class WebDavKeePassFileSource(
     private val normalizedRemotePath = normalizeOptionalRemotePath(remotePath)
     private val remoteUrl = buildRemoteUrl(normalizedServerUrl, normalizedRemotePath)
     private val sardine by lazy {
-        OkHttpSardine().apply {
-            if (username.isNotBlank() || password.isNotBlank()) {
-                setCredentials(username.trim(), password)
-            }
-        }
+        // 走统一的 Gateway：除了预置式 Basic 鉴权、速率限制与超时，
+        // 这里还需要继承用户选择的 HTTPS 证书校验档位。
+        // 历史实现直接裸构造 sardine 并调用 setCredentials，会绕过全部这些配置。
+        WebDavGateway.buildClient(WebDavCredentials(username.trim(), password))
     }
 
     override suspend fun stat(): FileSourceStat = withContext(Dispatchers.IO) {

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavGateway.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavGateway.kt
@@ -11,6 +11,10 @@ import java.util.concurrent.TimeUnit
  * [OkHttpSardine] 客户端。调用方（主要是 [takagi.ru.monica.utils.WebDavHelper]）
  * 只需通过该入口构造 sardine 客户端即可获得与 Kazumi (`webdav_client`) 等价的
  * 请求行为。
+ *
+ * HTTPS 证书校验策略由 [WebDavTlsSettings] 提供，见 [WebDavTlsMode]。
+ * 默认档位与引入该设置之前完全一致（平台默认强校验）。所有 WebDAV 出口都必须
+ * 经由本工厂构造客户端，否则会绕过用户选择的校验档位。
  */
 object WebDavGateway {
 
@@ -25,8 +29,13 @@ object WebDavGateway {
      * 重要：不再调用 `sardine.setCredentials(...)`，因为凭据已由
      * [PreemptiveBasicAuthInterceptor] 预置到每个请求中；双重设置反而会让
      * sardine 走 challenge-response 逻辑，与 OpenList 的速率策略冲突。
+     *
+     * @param tlsMode 证书校验档位；默认读取用户设置。显式传参主要供测试使用。
      */
-    fun buildHttpClient(credentials: WebDavCredentials): OkHttpClient =
+    fun buildHttpClient(
+        credentials: WebDavCredentials,
+        tlsMode: WebDavTlsMode = WebDavTlsSettings.currentMode(),
+    ): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -35,10 +44,13 @@ object WebDavGateway {
             .addInterceptor(PreemptiveBasicAuthInterceptor(credentials))
             .addInterceptor(RateLimitInterceptor())
             .addInterceptor(UserAgentInterceptor())
+            .apply { WebDavTlsSupport.configure(this, tlsMode) }
             .build()
 
-    fun buildClient(credentials: WebDavCredentials): OkHttpSardine =
-        OkHttpSardine(buildHttpClient(credentials))
+    fun buildClient(
+        credentials: WebDavCredentials,
+        tlsMode: WebDavTlsMode = WebDavTlsSettings.currentMode(),
+    ): OkHttpSardine = OkHttpSardine(buildHttpClient(credentials, tlsMode))
 
     /** 从任意 URL 字符串中提取 host；若无法解析返回空串。 */
     fun hostOf(url: String): String = WebDavUrlBuilder.hostOf(url)

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavTlsMode.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavTlsMode.kt
@@ -1,0 +1,46 @@
+package takagi.ru.monica.webdav
+
+/**
+ * WebDAV HTTPS 证书校验策略。
+ *
+ * 三档之间是严格的「安全性递减」关系，UI 必须按此顺序展示：
+ *
+ * 1. [SYSTEM_DEFAULT]：完全沿用 OkHttp / Android 平台默认行为，
+ *    即证书链必须由系统信任库签发，且主机名必须匹配。这是引入本设置之前
+ *    唯一存在的行为，选择该档时不会向 [okhttp3.OkHttpClient.Builder]
+ *    写入任何 TLS 相关配置。
+ * 2. [ALLOW_SELF_SIGNED]：先按系统信任库校验；失败时，若服务器出示的证书链
+ *    自身是闭合的（链尾为自签名证书），则把该链尾当作临时信任锚重新做一次
+ *    完整的路径校验。签名、有效期、基本约束仍然强制校验，主机名校验也仍然生效。
+ *    适用于自建 CA 或单张自签名证书的私有服务器。
+ * 3. [ALLOW_UNTRUSTED]：不校验证书链，也不校验主机名。等同于关闭 TLS 身份认证，
+ *    信道仍然加密但无法抵御中间人攻击。仅在用户明确知晓风险时使用。
+ */
+enum class WebDavTlsMode {
+    /** 系统默认校验（安全）。 */
+    SYSTEM_DEFAULT,
+
+    /** 额外接受自签名证书链（较安全）。 */
+    ALLOW_SELF_SIGNED,
+
+    /** 接受任意证书且不校验主机名（不安全）。 */
+    ALLOW_UNTRUSTED;
+
+    /** 是否偏离了平台默认校验；用于 UI 展示风险提示。 */
+    val isRelaxed: Boolean
+        get() = this != SYSTEM_DEFAULT
+
+    companion object {
+        /** 未配置时的默认档位，保持历史行为不变。 */
+        val DEFAULT: WebDavTlsMode = SYSTEM_DEFAULT
+
+        /**
+         * 从持久化字符串还原档位。
+         *
+         * 无法识别的值（包括 null、旧版本写入的未知枚举名）一律退回
+         * [DEFAULT]，确保降级时不会意外放宽校验。
+         */
+        fun fromStorage(raw: String?): WebDavTlsMode =
+            WebDavTlsMode.entries.firstOrNull { it.name == raw } ?: DEFAULT
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavTlsSettings.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavTlsSettings.kt
@@ -1,0 +1,93 @@
+package takagi.ru.monica.webdav
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * WebDAV TLS 校验档位的进程级单一数据源。
+ *
+ * 设计动机与 [WebDavBackoffState] 相同：[WebDavGateway] 是一个无 Context 的
+ * `object`，而 WorkManager 触发的后台备份可能运行在没有任何 Activity 的进程里，
+ * 因此档位必须能在不持有 Context 的情况下读取，同时又要在进程重启后仍然生效。
+ *
+ * 存储位置复用 `webdav_config` SharedPreferences，使
+ * [takagi.ru.monica.utils.WebDavHelper.clearConfig] 清空连接配置时能一并重置档位。
+ * 注意：档位本身不是敏感信息（不含凭据），因此按明文布尔/字符串存储即可，
+ * 无需经过 [takagi.ru.monica.security.SecurityManager]。
+ *
+ * 线程安全：写入走 `@Synchronized`，读取走 `@Volatile` 缓存字段。
+ */
+object WebDavTlsSettings {
+
+    internal const val PREFS_NAME = "webdav_config"
+    internal const val KEY_TLS_MODE = "webdav_tls_mode"
+
+    @Volatile
+    private var prefs: SharedPreferences? = null
+
+    @Volatile
+    private var cachedMode: WebDavTlsMode = WebDavTlsMode.DEFAULT
+
+    /**
+     * 绑定持久化存储并把已保存的档位载入内存缓存。
+     *
+     * 只需在应用启动阶段调用一次；重复调用会被忽略。
+     */
+    @Synchronized
+    fun attachPersistence(context: Context) {
+        if (prefs != null) return
+        val sharedPreferences = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs = sharedPreferences
+        cachedMode = WebDavTlsMode.fromStorage(
+            sharedPreferences.getString(KEY_TLS_MODE, null)
+        )
+    }
+
+    /**
+     * 当前生效的档位。
+     *
+     * 若尚未调用 [attachPersistence]（例如单元测试或极早期的初始化路径），
+     * 返回 [WebDavTlsMode.DEFAULT]，即最严格的校验。
+     */
+    fun currentMode(): WebDavTlsMode = cachedMode
+
+    /**
+     * 读取档位，必要时用传入的 Context 惰性绑定持久化。
+     *
+     * 供持有 Context 的调用方（如 [takagi.ru.monica.utils.WebDavHelper]）使用，
+     * 避免依赖 Application 初始化顺序。
+     */
+    fun currentMode(context: Context): WebDavTlsMode {
+        attachPersistence(context)
+        return cachedMode
+    }
+
+    /** 写入档位；同时更新内存缓存，使后续构造的客户端立即生效。 */
+    @Synchronized
+    fun setMode(context: Context, mode: WebDavTlsMode) {
+        attachPersistence(context)
+        cachedMode = mode
+        prefs?.edit()?.putString(KEY_TLS_MODE, mode.name)?.apply()
+    }
+
+    /**
+     * 重置为默认档位并清除持久化值；供清除 WebDAV 配置时调用。
+     *
+     * 需要 [context] 是因为清除配置的调用点可能早于 Application 初始化
+     * （例如 WorkManager 直接实例化 WebDavHelper），此时必须先绑定持久化，
+     * 否则旧档位只会从内存里消失、下次冷启动又被读回来。
+     */
+    @Synchronized
+    fun reset(context: Context) {
+        attachPersistence(context)
+        cachedMode = WebDavTlsMode.DEFAULT
+        prefs?.edit()?.remove(KEY_TLS_MODE)?.apply()
+    }
+
+    /** 仅测试用：解除持久化绑定并恢复默认档位。 */
+    internal fun resetForTest() {
+        prefs = null
+        cachedMode = WebDavTlsMode.DEFAULT
+    }
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavTlsSupport.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/webdav/WebDavTlsSupport.kt
@@ -1,0 +1,236 @@
+package takagi.ru.monica.webdav
+
+import android.annotation.SuppressLint
+import java.security.KeyStore
+import java.security.SecureRandom
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSession
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+import okhttp3.OkHttpClient
+
+/**
+ * 按 [WebDavTlsMode] 为 OkHttp 客户端装配 TLS 校验行为。
+ *
+ * 安全边界说明（务必在修改前阅读）：
+ * - [WebDavTlsMode.SYSTEM_DEFAULT] 分支**不写入任何** TLS 配置，从而完整继承
+ *   OkHttp / Android 平台默认实现（含平台的证书透明度与 API 级别相关行为）。
+ *   这一点很重要：手工构造 `SSLContext.getInstance("TLS")` 即使配置等价，
+ *   也会绕过 Android 的 `X509TrustManagerExtensions` 优化路径。
+ * - [WebDavTlsMode.ALLOW_SELF_SIGNED] 仍然做完整的证书路径校验（签名、有效期、
+ *   基本约束）与主机名校验，只是额外允许「服务器出示的自签名链尾」充当信任锚。
+ *   它不会接受一条无法自洽的链，也不会接受主机名不匹配的证书。
+ * - [WebDavTlsMode.ALLOW_UNTRUSTED] 才是真正的放行档，会同时关闭链校验与
+ *   主机名校验。仅在用户于 UI 上二次确认后才应被选中。
+ *
+ * [SSLSocketFactory] 的构造有明显开销，因此按档位缓存；档位切换后重新构造的
+ * 客户端会拿到对应缓存实例。
+ */
+internal object WebDavTlsSupport {
+
+    private val selfSignedFactoryLock = Any()
+
+    @Volatile
+    private var selfSignedFactory: TrustSetup? = null
+
+    private val insecureFactoryLock = Any()
+
+    @Volatile
+    private var insecureFactory: TrustSetup? = null
+
+    private data class TrustSetup(
+        val socketFactory: SSLSocketFactory,
+        val trustManager: X509TrustManager,
+    )
+
+    /**
+     * 把 [mode] 对应的校验策略应用到 [builder] 上。
+     *
+     * 任何一步失败都会静默退回系统默认校验（fail-secure），而不是抛异常中断
+     * 备份流程；失败原因写入日志，不包含证书内容。
+     */
+    fun configure(builder: OkHttpClient.Builder, mode: WebDavTlsMode) {
+        when (mode) {
+            // 关键：这里必须什么都不做，见类注释。
+            WebDavTlsMode.SYSTEM_DEFAULT -> Unit
+
+            WebDavTlsMode.ALLOW_SELF_SIGNED -> {
+                val setup = runCatching { selfSignedSetup() }.getOrNull()
+                if (setup == null) {
+                    android.util.Log.w(TAG, "Falling back to system TLS: self-signed setup failed")
+                    return
+                }
+                builder.sslSocketFactory(setup.socketFactory, setup.trustManager)
+                // 主机名校验保持默认：自签名不等于可以冒充任意域名。
+            }
+
+            WebDavTlsMode.ALLOW_UNTRUSTED -> {
+                val setup = runCatching { insecureSetup() }.getOrNull()
+                if (setup == null) {
+                    android.util.Log.w(TAG, "Falling back to system TLS: insecure setup failed")
+                    return
+                }
+                builder.sslSocketFactory(setup.socketFactory, setup.trustManager)
+                builder.hostnameVerifier(AllowAllHostnameVerifier)
+            }
+        }
+    }
+
+    private fun selfSignedSetup(): TrustSetup {
+        selfSignedFactory?.let { return it }
+        return synchronized(selfSignedFactoryLock) {
+            selfSignedFactory?.let { return it }
+            val trustManager = SelfSignedTolerantTrustManager(systemDefaultTrustManager())
+            val created = TrustSetup(socketFactoryFor(trustManager), trustManager)
+            selfSignedFactory = created
+            created
+        }
+    }
+
+    private fun insecureSetup(): TrustSetup {
+        insecureFactory?.let { return it }
+        return synchronized(insecureFactoryLock) {
+            insecureFactory?.let { return it }
+            val trustManager = TrustAnyServerTrustManager()
+            val created = TrustSetup(socketFactoryFor(trustManager), trustManager)
+            insecureFactory = created
+            created
+        }
+    }
+
+    private fun socketFactoryFor(trustManager: X509TrustManager): SSLSocketFactory {
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(null, arrayOf<TrustManager>(trustManager), SecureRandom())
+        return sslContext.socketFactory
+    }
+
+    private fun systemDefaultTrustManager(): X509TrustManager {
+        val factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        factory.init(null as KeyStore?)
+        return factory.trustManagers
+            .filterIsInstance<X509TrustManager>()
+            .firstOrNull()
+            ?: throw IllegalStateException("No system X509TrustManager available")
+    }
+
+    /**
+     * 仅测试用：在指定的基准 trust manager 之上包一层自签名容忍逻辑。
+     *
+     * 生产代码始终以系统信任库为基准；测试需要注入一个信任私有 CA 的基准，
+     * 才能验证「链本身可信时行为不变」这条性质。
+     */
+    internal fun selfSignedTolerantTrustManagerForTest(
+        base: X509TrustManager,
+    ): X509TrustManager = SelfSignedTolerantTrustManager(base)
+
+    /**
+     * 在系统信任库之外，额外接受「自洽的自签名证书链」。
+     *
+     * 校验顺序：
+     * 1. 先交给系统 trust manager；通过则直接返回，公有 CA 场景零行为变化。
+     * 2. 系统拒绝时，取链尾证书，要求它是自签名的（subject == issuer 且能用
+     *    自身公钥验签）。不满足则沿用系统的拒绝结果。
+     * 3. 把该链尾装进临时 KeyStore 作为唯一信任锚，用标准
+     *    [TrustManagerFactory] 重新校验完整链。这一步会继续检查中间证书签名、
+     *    有效期与基本约束，因此攻击者无法用一张随意伪造的叶证书通过校验
+     *    （除非用户机器已经在信任那张自签名根）。
+     *
+     * 该实现被 lint 的 `CustomX509TrustManager` 规则命中，但它并非放行实现，
+     * 故就地抑制而非写入 lint baseline。
+     */
+    @SuppressLint("CustomX509TrustManager")
+    private class SelfSignedTolerantTrustManager(
+        private val systemTrustManager: X509TrustManager,
+    ) : X509TrustManager {
+
+        override fun checkClientTrusted(chain: Array<X509Certificate>?, authType: String?) {
+            // 客户端证书不在本功能范围内，直接沿用系统判定。
+            systemTrustManager.checkClientTrusted(chain, authType)
+        }
+
+        override fun checkServerTrusted(chain: Array<X509Certificate>?, authType: String?) {
+            if (chain == null || chain.isEmpty()) {
+                throw CertificateException("Empty server certificate chain")
+            }
+
+            val systemFailure = try {
+                systemTrustManager.checkServerTrusted(chain, authType)
+                return
+            } catch (error: CertificateException) {
+                error
+            }
+
+            val anchor = chain.last()
+            if (!isSelfSigned(anchor)) {
+                // 链尾不是自签名，说明缺失的是中间证书或确实由不受信 CA 签发，
+                // 这类情况不属于「自签名服务器」，保持系统的拒绝语义。
+                throw systemFailure
+            }
+
+            try {
+                anchorTrustManager(anchor).checkServerTrusted(chain, authType)
+            } catch (error: Exception) {
+                throw CertificateException(
+                    "Self-signed chain validation failed: ${error.message}",
+                    systemFailure
+                )
+            }
+        }
+
+        /**
+         * 只暴露系统信任锚。
+         *
+         * 自签名锚是逐连接动态发现的，无法在此静态枚举；返回系统列表可以让
+         * TLS 握手继续按常规方式协商，同时不会向服务器泄露额外信息。
+         */
+        override fun getAcceptedIssuers(): Array<X509Certificate> =
+            systemTrustManager.acceptedIssuers
+
+        private fun isSelfSigned(certificate: X509Certificate): Boolean {
+            if (certificate.subjectX500Principal != certificate.issuerX500Principal) return false
+            return runCatching { certificate.verify(certificate.publicKey) }.isSuccess
+        }
+
+        private fun anchorTrustManager(anchor: X509Certificate): X509TrustManager {
+            val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply {
+                load(null)
+                setCertificateEntry("webdav-self-signed-anchor", anchor)
+            }
+            val factory = TrustManagerFactory.getInstance(
+                TrustManagerFactory.getDefaultAlgorithm()
+            )
+            factory.init(keyStore)
+            return factory.trustManagers
+                .filterIsInstance<X509TrustManager>()
+                .firstOrNull()
+                ?: throw IllegalStateException("No X509TrustManager for self-signed anchor")
+        }
+    }
+
+    /**
+     * 接受任意服务器证书。
+     *
+     * 这是有意为之的放行实现，配合 [AllowAllHostnameVerifier] 一起使用，
+     * 仅在用户显式选择 [WebDavTlsMode.ALLOW_UNTRUSTED] 并二次确认后启用。
+     * lint 的 `TrustAllX509TrustManager` 命中属预期，就地抑制。
+     */
+    @SuppressLint("CustomX509TrustManager", "TrustAllX509TrustManager")
+    private class TrustAnyServerTrustManager : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<X509Certificate>?, authType: String?) = Unit
+        override fun checkServerTrusted(chain: Array<X509Certificate>?, authType: String?) = Unit
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+
+    /** 与 [TrustAnyServerTrustManager] 配套的主机名放行实现。 */
+    @SuppressLint("BadHostnameVerifier")
+    private object AllowAllHostnameVerifier : HostnameVerifier {
+        override fun verify(hostname: String?, session: SSLSession?): Boolean = true
+    }
+
+    private const val TAG = "WebDavTls"
+}

--- a/Monica for Android/app/src/main/res/values-zh/strings.xml
+++ b/Monica for Android/app/src/main/res/values-zh/strings.xml
@@ -1664,6 +1664,23 @@
     <string name="webdav_enter_decrypt_password">输入解密密码</string>
     <string name="webdav_decrypt_password_hint">用于解密备份的密码</string>
     <string name="webdav_decryption_failed">解密失败: 密码错误或文件已损坏</string>
+
+    <!-- WebDAV HTTPS 证书校验 -->
+    <string name="webdav_tls_title">HTTPS 证书校验</string>
+    <string name="webdav_tls_description">控制如何校验服务器的 HTTPS 证书。仅在服务器使用私有证书时才需要放宽。</string>
+    <string name="webdav_tls_mode_system_title">系统校验（推荐）</string>
+    <string name="webdav_tls_mode_system_desc">证书必须由受信任的 CA 签发，且主机名必须匹配。</string>
+    <string name="webdav_tls_mode_self_signed_title">允许自签名证书</string>
+    <string name="webdav_tls_mode_self_signed_desc">额外接受自签名证书链；签名、有效期与主机名仍会校验。</string>
+    <string name="webdav_tls_mode_untrusted_title">允许不受信证书</string>
+    <string name="webdav_tls_mode_untrusted_desc">接受任意证书且跳过主机名校验，无法防御中间人窃听。</string>
+    <string name="webdav_tls_current_mode">当前：%s</string>
+    <string name="webdav_tls_changed">证书校验方式已更新，请重新测试连接。</string>
+    <string name="webdav_tls_relaxed_banner">证书校验已放宽。备份文件包含你的整个密码库。</string>
+    <string name="webdav_tls_confirm_title">确认放宽证书校验？</string>
+    <string name="webdav_tls_confirm_self_signed">备份文件包含你的整个密码库。自签名证书无法由任何权威机构验证，请确认该服务器由你自己掌控。\n\n签名、有效期与主机名仍会校验。</string>
+    <string name="webdav_tls_confirm_untrusted">这会完全关闭 TLS 身份认证。任何能够劫持该连接的人都可以冒充你的服务器并取走备份，而备份中包含你的整个密码库。\n\n请仅在可信网络下临时使用，用完后及时切回。</string>
+    <string name="webdav_tls_confirm_accept">我已了解，继续</string>
     
     <!-- WebDAV Auto Backup -->
     <string name="webdav_auto_backup">自动备份</string>

--- a/Monica for Android/app/src/main/res/values/strings.xml
+++ b/Monica for Android/app/src/main/res/values/strings.xml
@@ -1690,6 +1690,23 @@
     <string name="webdav_enter_decrypt_password">Enter Decryption Password</string>
     <string name="webdav_decrypt_password_hint">Password to decrypt backup</string>
     <string name="webdav_decryption_failed">Decryption failed: Wrong password or corrupted file</string>
+
+    <!-- WebDAV HTTPS certificate verification -->
+    <string name="webdav_tls_title">HTTPS Certificate Verification</string>
+    <string name="webdav_tls_description">Controls how the server\'s HTTPS certificate is checked. Only relax this if your server uses a private certificate.</string>
+    <string name="webdav_tls_mode_system_title">System verification (recommended)</string>
+    <string name="webdav_tls_mode_system_desc">Certificate must be issued by a trusted CA and match the hostname.</string>
+    <string name="webdav_tls_mode_self_signed_title">Allow self-signed certificates</string>
+    <string name="webdav_tls_mode_self_signed_desc">Also accepts a self-signed chain. Signature, expiry and hostname are still verified.</string>
+    <string name="webdav_tls_mode_untrusted_title">Allow untrusted certificates</string>
+    <string name="webdav_tls_mode_untrusted_desc">Accepts any certificate and skips hostname checks. No protection against interception.</string>
+    <string name="webdav_tls_current_mode">Current: %s</string>
+    <string name="webdav_tls_changed">Certificate verification updated. Test the connection again.</string>
+    <string name="webdav_tls_relaxed_banner">Certificate verification is relaxed. Backups contain your entire vault.</string>
+    <string name="webdav_tls_confirm_title">Weaken certificate verification?</string>
+    <string name="webdav_tls_confirm_self_signed">Your backups contain the whole vault. A self-signed certificate cannot be verified by any authority, so make sure the server is one you control.\n\nSignature, expiry and hostname are still checked.</string>
+    <string name="webdav_tls_confirm_untrusted">This disables TLS identity checks entirely. Anyone able to intercept the connection can impersonate your server and capture the backup, which contains your whole vault.\n\nOnly use this on a network you trust, and switch back afterwards.</string>
+    <string name="webdav_tls_confirm_accept">I understand, continue</string>
     
     <!-- WebDAV Auto Backup -->
     <string name="webdav_auto_backup">Auto Backup</string>

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/webdav/WebDavTlsGatewayWiringTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/webdav/WebDavTlsGatewayWiringTest.kt
@@ -1,0 +1,113 @@
+package takagi.ru.monica.webdav
+
+import java.nio.file.Paths
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 源码级守卫：确保 TLS 档位真的被接到了每一个 WebDAV 出口上。
+ *
+ * 这类断言比行为测试脆弱，但这里是刻意的：
+ * [WebDavGateway] 的完整客户端依赖 `android.util.Base64` 与 `BuildConfig`，
+ * 在 JVM 单元测试里无法实例化；而「有人新增了一处绕过 Gateway 的
+ * `OkHttpSardine()`」正是本功能最容易被悄悄破坏的方式。
+ * 与 [takagi.ru.monica.utils.WebDavSecurityStorageGuardTest] 采用同一模式。
+ */
+class WebDavTlsGatewayWiringTest {
+
+    @Test
+    fun gateway_appliesTlsModeAndDefaultsToUserSetting() {
+        val source = projectFile("app/src/main/java/takagi/ru/monica/webdav/WebDavGateway.kt")
+
+        assertTrue(source.contains("WebDavTlsSupport.configure(this, tlsMode)"))
+        assertTrue(source.contains("tlsMode: WebDavTlsMode = WebDavTlsSettings.currentMode()"))
+    }
+
+    @Test
+    fun systemDefaultMode_writesNoTlsConfigurationAtAll() {
+        val source = projectFile("app/src/main/java/takagi/ru/monica/webdav/WebDavTlsSupport.kt")
+
+        // 默认档必须是一个空分支：任何手工 SSLContext 都会绕过平台优化路径。
+        assertTrue(source.contains("WebDavTlsMode.SYSTEM_DEFAULT -> Unit"))
+    }
+
+    @Test
+    fun hostnameVerificationIsOnlyDisabledForTheUntrustedMode() {
+        val source = projectFile("app/src/main/java/takagi/ru/monica/webdav/WebDavTlsSupport.kt")
+
+        val untrustedBranch = source.substringAfter("WebDavTlsMode.ALLOW_UNTRUSTED -> {")
+        assertTrue(untrustedBranch.contains("hostnameVerifier(AllowAllHostnameVerifier)"))
+
+        val selfSignedBranch = source
+            .substringAfter("WebDavTlsMode.ALLOW_SELF_SIGNED -> {")
+            .substringBefore("WebDavTlsMode.ALLOW_UNTRUSTED ->")
+        assertFalse(selfSignedBranch.contains("hostnameVerifier"))
+    }
+
+    @Test
+    fun everyWebDavClientGoesThroughTheGateway() {
+        // 绕过 Gateway 直接构造 sardine 会丢掉 TLS 档位、超时与鉴权拦截器。
+        listOf(
+            "app/src/main/java/takagi/ru/monica/utils/WebDavKeePassFileSource.kt",
+            "app/src/main/java/takagi/ru/monica/utils/WebDavHelper.kt",
+        ).forEach { path ->
+            val source = projectFile(path)
+            assertFalse(
+                "$path must not construct a bare OkHttpSardine()",
+                source.contains("OkHttpSardine()")
+            )
+        }
+
+        assertTrue(
+            projectFile("app/src/main/java/takagi/ru/monica/utils/WebDavKeePassFileSource.kt")
+                .contains("WebDavGateway.buildClient(")
+        )
+        assertTrue(
+            projectFile("app/src/main/java/takagi/ru/monica/utils/WebDavMdbxFileSource.kt")
+                .contains("WebDavGateway.buildHttpClient(")
+        )
+    }
+
+    @Test
+    fun tlsModeIsAttachedAtApplicationStartup() {
+        val source = projectFile("app/src/main/java/takagi/ru/monica/MonicaApplication.kt")
+
+        // 后台备份进程没有 Activity，必须在 Application 阶段绑定持久化。
+        assertTrue(source.contains("WebDavTlsSettings.attachPersistence(this)"))
+    }
+
+    @Test
+    fun clearingWebDavConfigAlsoResetsTlsMode() {
+        val source = projectFile("app/src/main/java/takagi/ru/monica/utils/WebDavHelper.kt")
+
+        assertTrue(source.contains("WebDavTlsSettings.reset(context)"))
+        // 切档后必须重建客户端，否则新档位要等冷启动才生效。
+        assertTrue(source.contains("fun setTlsMode("))
+        assertTrue(source.contains("sardine = createSardineClient()"))
+    }
+
+    @Test
+    fun relaxedModesRequireExplicitConfirmationInUi() {
+        val source = projectFile(
+            "app/src/main/java/takagi/ru/monica/ui/screens/WebDavBackupScreen.kt"
+        )
+
+        assertTrue(source.contains("if (mode.isRelaxed)"))
+        assertTrue(source.contains("pendingTlsMode = mode"))
+        assertTrue(source.contains("WebDavTlsRelaxConfirmDialog("))
+    }
+
+    private fun projectFile(relativePath: String): String {
+        val start = Paths.get("").toAbsolutePath()
+        var cursor = start
+        while (cursor.parent != null) {
+            val candidate = cursor.resolve(relativePath).toFile()
+            if (candidate.exists()) {
+                return candidate.readText()
+            }
+            cursor = cursor.parent
+        }
+        error("Project file not found from $start: $relativePath")
+    }
+}

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/webdav/WebDavTlsSupportTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/webdav/WebDavTlsSupportTest.kt
@@ -1,0 +1,250 @@
+package takagi.ru.monica.webdav
+
+import java.io.IOException
+import java.net.InetAddress
+import java.security.SecureRandom
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.TrustManager
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 用真实 TLS 握手验证三档校验策略，而不是断言 OkHttp 的内部字段。
+ *
+ * MockWebServer 出示一张自签名证书；由于测试 JVM 的信任库里没有这张证书，
+ * 它同时满足「自签名」与「不受信」两种场景，正好覆盖三档的分界行为。
+ *
+ * 注意：这些用例不依赖 Android framework，因此可以在 JVM 单元测试里跑。
+ * [WebDavGateway] 的完整客户端会引入 android.util.Base64 与 BuildConfig，
+ * 故这里直接测 [WebDavTlsSupport]，与 Gateway 的接线由
+ * [WebDavTlsGatewayWiringTest] 用源码断言覆盖。
+ */
+class WebDavTlsSupportTest {
+
+    private var server: MockWebServer? = null
+
+    @After
+    fun tearDown() {
+        server?.shutdown()
+        server = null
+        WebDavTlsSettings.resetForTest()
+    }
+
+    @Test
+    fun systemDefaultMode_rejectsSelfSignedCertificate() {
+        val url = startSelfSignedServer()
+        val error = get(clientFor(WebDavTlsMode.SYSTEM_DEFAULT), url)
+
+        assertTrue(
+            "Expected a handshake failure, got: $error",
+            error is SSLHandshakeException
+        )
+    }
+
+    @Test
+    fun allowSelfSignedMode_acceptsSelfSignedCertificate() {
+        val url = startSelfSignedServer()
+        val client = clientFor(WebDavTlsMode.ALLOW_SELF_SIGNED)
+
+        client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+            assertEquals(200, response.code)
+        }
+    }
+
+    @Test
+    fun allowUntrustedMode_acceptsSelfSignedCertificate() {
+        val url = startSelfSignedServer()
+        val client = clientFor(WebDavTlsMode.ALLOW_UNTRUSTED)
+
+        client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+            assertEquals(200, response.code)
+        }
+    }
+
+    /**
+     * 自签名档必须继续校验主机名。这是它与放行档最重要的区别：证书为
+     * `localhost` 签发，用 `127.0.0.1` 访问时应被主机名校验拦下。
+     */
+    @Test
+    fun allowSelfSignedMode_stillVerifiesHostname() {
+        val url = startSelfSignedServer(certificateHostname = "wrong-host.invalid")
+        val error = get(clientFor(WebDavTlsMode.ALLOW_SELF_SIGNED), url)
+
+        assertTrue(
+            "Hostname verification must remain active, got: $error",
+            error is SSLHandshakeException || error is javax.net.ssl.SSLPeerUnverifiedException
+        )
+    }
+
+    /** 放行档同时关闭主机名校验。 */
+    @Test
+    fun allowUntrustedMode_skipsHostnameVerification() {
+        val url = startSelfSignedServer(certificateHostname = "wrong-host.invalid")
+        val client = clientFor(WebDavTlsMode.ALLOW_UNTRUSTED)
+
+        client.newCall(Request.Builder().url(url).build()).execute().use { response ->
+            assertEquals(200, response.code)
+        }
+    }
+
+    /**
+     * 自签名档在服务器证书由受信 CA 签发时不得改变行为。
+     *
+     * 这里搭一条「私有 CA -> 叶证书」的真实链，并把「信任该 CA 的
+     * trust manager」作为容忍层的基准。叶证书不是自签名的，因此走的是
+     * `checkServerTrusted` 里系统校验直接通过的那条路径——也就是说，
+     * 容忍逻辑对正常链是完全透明的。
+     */
+    @Test
+    fun allowSelfSignedMode_doesNotChangeTrustedChainBehaviour() {
+        val rootCa = HeldCertificate.Builder()
+            .certificateAuthority(0)
+            .commonName("Monica Test Root")
+            .build()
+        val leaf = HeldCertificate.Builder()
+            .commonName("localhost")
+            .addSubjectAlternativeName("localhost")
+            .signedBy(rootCa)
+            .build()
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(leaf, rootCa.certificate)
+            .build()
+
+        val started = MockWebServer().apply {
+            useHttps(serverCertificates.sslSocketFactory(), false)
+            enqueue(MockResponse().setResponseCode(200))
+            start(InetAddress.getByName("localhost"), 0)
+        }
+        server = started
+
+        val trustingCa = HandshakeCertificates.Builder()
+            .addTrustedCertificate(rootCa.certificate)
+            .build()
+            .trustManager
+        val tolerant = WebDavTlsSupport.selfSignedTolerantTrustManagerForTest(trustingCa)
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(null, arrayOf<TrustManager>(tolerant), SecureRandom())
+        }
+        val client = OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.socketFactory, tolerant)
+            .build()
+
+        client.newCall(Request.Builder().url(started.probeUrl()).build()).execute()
+            .use { response -> assertEquals(200, response.code) }
+    }
+
+    /**
+     * 容忍层不得放过「链尾不是自签名」的失败，例如缺失中间证书、
+     * 或由一个客户端并不信任的真实 CA 签发的链。
+     */
+    @Test
+    fun allowSelfSignedMode_rejectsChainWhoseAnchorIsNotSelfSigned() {
+        val rootCa = HeldCertificate.Builder()
+            .certificateAuthority(0)
+            .commonName("Monica Untrusted Root")
+            .build()
+        val leaf = HeldCertificate.Builder()
+            .commonName("localhost")
+            .addSubjectAlternativeName("localhost")
+            .signedBy(rootCa)
+            .build()
+        // 只出示叶证书，不带 CA：链尾是叶证书，且它不是自签名的。
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(leaf)
+            .build()
+
+        val started = MockWebServer().apply {
+            useHttps(serverCertificates.sslSocketFactory(), false)
+            enqueue(MockResponse().setResponseCode(200))
+            start(InetAddress.getByName("localhost"), 0)
+        }
+        server = started
+
+        val error = get(clientFor(WebDavTlsMode.ALLOW_SELF_SIGNED), started.probeUrl())
+        assertTrue(
+            "A non-self-signed untrusted anchor must still be rejected, got: $error",
+            error is SSLHandshakeException
+        )
+    }
+
+    /** SSLSocketFactory 构造有开销，同一档位必须复用缓存实例。 */
+    @Test
+    fun relaxedModes_reuseCachedSocketFactory() {
+        val first = clientFor(WebDavTlsMode.ALLOW_SELF_SIGNED).sslSocketFactory
+        val second = clientFor(WebDavTlsMode.ALLOW_SELF_SIGNED).sslSocketFactory
+        assertSame(first, second)
+    }
+
+    @Test
+    fun unknownStoredValue_fallsBackToStrictDefault() {
+        assertEquals(WebDavTlsMode.SYSTEM_DEFAULT, WebDavTlsMode.fromStorage(null))
+        assertEquals(WebDavTlsMode.SYSTEM_DEFAULT, WebDavTlsMode.fromStorage(""))
+        assertEquals(WebDavTlsMode.SYSTEM_DEFAULT, WebDavTlsMode.fromStorage("ALLOW_EVERYTHING"))
+        assertEquals(
+            WebDavTlsMode.ALLOW_UNTRUSTED,
+            WebDavTlsMode.fromStorage("ALLOW_UNTRUSTED")
+        )
+    }
+
+    @Test
+    fun isRelaxed_onlyTrueForNonDefaultModes() {
+        assertFalse(WebDavTlsMode.SYSTEM_DEFAULT.isRelaxed)
+        assertTrue(WebDavTlsMode.ALLOW_SELF_SIGNED.isRelaxed)
+        assertTrue(WebDavTlsMode.ALLOW_UNTRUSTED.isRelaxed)
+    }
+
+    /** 未绑定 Context 时必须返回最严格的档位。 */
+    @Test
+    fun currentMode_defaultsToStrictWithoutPersistence() {
+        WebDavTlsSettings.resetForTest()
+        assertEquals(WebDavTlsMode.SYSTEM_DEFAULT, WebDavTlsSettings.currentMode())
+    }
+
+    private fun clientFor(mode: WebDavTlsMode): OkHttpClient =
+        OkHttpClient.Builder()
+            .apply { WebDavTlsSupport.configure(this, mode) }
+            .build()
+
+    /**
+     * MockWebServer.url() 会返回 `127.0.0.1`，而测试证书的 SAN 是主机名，
+     * 直接使用会先撞上主机名校验，掩盖我们真正想验证的链校验行为。
+     */
+    private fun MockWebServer.probeUrl(host: String = "localhost"): String =
+        url("/probe").newBuilder().host(host).build().toString()
+
+    private fun startSelfSignedServer(certificateHostname: String = "localhost"): String {
+        val certificate = HeldCertificate.Builder()
+            .commonName(certificateHostname)
+            .addSubjectAlternativeName(certificateHostname)
+            .build()
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(certificate)
+            .build()
+
+        val started = MockWebServer().apply {
+            useHttps(serverCertificates.sslSocketFactory(), false)
+            enqueue(MockResponse().setResponseCode(200))
+            start(InetAddress.getByName("localhost"), 0)
+        }
+        server = started
+        return started.probeUrl()
+    }
+
+    private fun get(client: OkHttpClient, url: String): Throwable? = try {
+        client.newCall(Request.Builder().url(url).build()).execute().close()
+        null
+    } catch (error: IOException) {
+        error
+    }
+}


### PR DESCRIPTION
WebDAV backups previously always used the platform default TLS validation, so a self-signed server could not be reached at all. Add a three-way setting on the WebDAV backup screen:

- SYSTEM_DEFAULT: unchanged behaviour, writes no TLS config so OkHttp and the Android platform defaults stay fully intact
- ALLOW_SELF_SIGNED: retries validation using the server's self-signed chain tail as a temporary anchor; signature, expiry, basic constraints and hostname are all still enforced
- ALLOW_UNTRUSTED: accepts any certificate and skips hostname checks

Both relaxed modes require an explicit confirmation dialog, and the selection card shows a persistent warning while verification is relaxed. The mode is stored in the existing webdav_config prefs and is reset when the connection config is cleared, so a relaxed setting cannot leak to a different server. Unknown stored values fall back to strict validation.

Also route WebDavKeePassFileSource through WebDavGateway; it was building a bare sardine client and therefore missed the timeouts, rate-limit interceptor and preemptive auth in addition to the new TLS mode.