### PR TITLE
Android：优化密码列表运行时性能，并引入 Rust 核心

### DIFF
--- a/.github/workflows/Android-Preview.yml
+++ b/.github/workflows/Android-Preview.yml
@@ -10,6 +10,8 @@ on:
       - 'Monica for Android/**/*.gradle'
       - 'Monica for Android/**/*.kts'
       - 'Monica for Android/gradle/**'
+      - 'Monica for Android/rust-core/**'
+      - 'Monica for Android/rust-jni/**'
   pull_request:
     branches: [ main, develop ]
     paths:
@@ -19,6 +21,8 @@ on:
       - 'Monica for Android/**/*.gradle'
       - 'Monica for Android/**/*.kts'
       - 'Monica for Android/gradle/**'
+      - 'Monica for Android/rust-core/**'
+      - 'Monica for Android/rust-jni/**'
   workflow_dispatch:
 
 permissions:
@@ -52,6 +56,25 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('Monica for Android/**/*.gradle*', 'Monica for Android/**/gradle-wrapper.properties') }}
+
+      - name: Set up Rust Android toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add aarch64-linux-android armv7-linux-androideabi
+          cargo install cargo-ndk --locked
+
+      - name: Build Rust JNI for preview ABIs
+        shell: bash
+        run: |
+          cargo ndk \
+            -t arm64-v8a \
+            -t armeabi-v7a \
+            -o app/src/main/jniLibs \
+            build --release --manifest-path rust-jni/Cargo.toml
+          test -f app/src/main/jniLibs/arm64-v8a/libmonica_rust_jni.so
+          test -f app/src/main/jniLibs/armeabi-v7a/libmonica_rust_jni.so
           
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -30,6 +30,26 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
+
+      - name: Set up Rust Android toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add aarch64-linux-android armv7-linux-androideabi
+          cargo install cargo-ndk --locked
+
+      - name: Build Rust JNI for release ABIs
+        shell: bash
+        run: |
+          cargo ndk \
+            -t arm64-v8a \
+            -t armeabi-v7a \
+            -o app/src/main/jniLibs \
+            build --release --manifest-path rust-jni/Cargo.toml
+          test -f app/src/main/jniLibs/arm64-v8a/libmonica_rust_jni.so
+          test -f app/src/main/jniLibs/armeabi-v7a/libmonica_rust_jni.so
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Decode keystore
@@ -139,4 +159,3 @@ jobs:
                 release_tag: process.env.RELEASE_TAG,
               },
             });
-

--- a/.github/workflows/Rust-Core.yml
+++ b/.github/workflows/Rust-Core.yml
@@ -1,0 +1,48 @@
+name: Rust Core
+
+on:
+  pull_request:
+    paths:
+      - "Monica for Android/rust-core/**"
+      - "Monica for Android/rust-jni/**"
+      - ".github/workflows/Rust-Core.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "Monica for Android/rust-core/**"
+      - "Monica for Android/rust-jni/**"
+      - ".github/workflows/Rust-Core.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: "Monica for Android"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt,clippy
+          rustup default stable
+
+      - name: Check core formatting
+        run: cargo fmt --manifest-path rust-core/Cargo.toml --all -- --check
+
+      - name: Run core Clippy
+        run: cargo clippy --manifest-path rust-core/Cargo.toml --all-targets --all-features -- -D warnings
+
+      - name: Run core tests
+        run: cargo test --manifest-path rust-core/Cargo.toml --all-targets --all-features
+
+      - name: Check JNI formatting
+        run: cargo fmt --manifest-path rust-jni/Cargo.toml --all -- --check
+
+      - name: Run JNI Clippy
+        run: cargo clippy --manifest-path rust-jni/Cargo.toml --all-targets --all-features -- -D warnings

--- a/Monica for Android/app/proguard-rules.pro
+++ b/Monica for Android/app/proguard-rules.pro
@@ -67,6 +67,9 @@
     public static final ** CREATOR;
 }
 
+# Rust JNI uses statically exported Java_* symbols, so R8 must not rename this facade.
+-keep class takagi.ru.monica.rustcore.RustPasswordListCore { *; }
+
 # 移除日志 (Release构建)
 -assumenosideeffects class android.util.Log {
     public static *** d(...);

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/rustcore/RustPasswordListCore.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/rustcore/RustPasswordListCore.kt
@@ -1,0 +1,79 @@
+package takagi.ru.monica.rustcore
+
+import takagi.ru.monica.data.PasswordEntry
+
+/**
+ * Single-batch JNI facade for secret-free password-list metadata.
+ *
+ * The native boundary deliberately excludes PasswordEntry.password and every other
+ * sensitive credential value. If the native library is unavailable or rejects a
+ * batch, callers get null and must keep the Kotlin/Room fallback path.
+ */
+object RustPasswordListCore {
+    @Volatile
+    private var loadAttempted = false
+
+    @Volatile
+    private var nativeAvailable = false
+
+    private fun ensureLoaded(): Boolean {
+        if (!loadAttempted) {
+            synchronized(this) {
+                if (!loadAttempted) {
+                    nativeAvailable = runCatching {
+                        System.loadLibrary("monica_rust_jni")
+                        nativeSelfTest()
+                    }.getOrDefault(false)
+                    loadAttempted = true
+                }
+            }
+        }
+        return nativeAvailable
+    }
+
+    fun filterEntries(entries: List<PasswordEntry>, query: String): List<PasswordEntry>? {
+        if (!ensureLoaded()) return null
+        if (entries.isEmpty()) return emptyList()
+
+        val selectedIds = runCatching {
+            nativeFilterIds(
+                ids = entries.map { it.id }.toLongArray(),
+                titles = entries.map { it.title }.toTypedArray(),
+                usernames = entries.map { it.username }.toTypedArray(),
+                websites = entries.map { it.website }.toTypedArray(),
+                appNames = entries.map { it.appName }.toTypedArray(),
+                appPackageNames = entries.map { it.appPackageName }.toTypedArray(),
+                query = query,
+            )
+        }.getOrNull() ?: return null
+
+        val entriesById = entries.associateBy { it.id }
+        return selectedIds
+            .asSequence()
+            .mapNotNull { id -> entriesById[id] }
+            .toList()
+    }
+
+    fun diagnosticLabel(): String = if (!ensureLoaded()) {
+        "Rust core unavailable"
+    } else {
+        runCatching { nativeVersion() }.getOrDefault("Rust core loaded")
+    }
+
+    @JvmStatic
+    private external fun nativeVersion(): String
+
+    @JvmStatic
+    private external fun nativeSelfTest(): Boolean
+
+    @JvmStatic
+    private external fun nativeFilterIds(
+        ids: LongArray,
+        titles: Array<String>,
+        usernames: Array<String>,
+        websites: Array<String>,
+        appNames: Array<String>,
+        appPackageNames: Array<String>,
+        query: String,
+    ): LongArray?
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/password/PasswordEntryCard.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/password/PasswordEntryCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -117,8 +118,14 @@ fun PasswordEntryCard(
                         val uploadedIcon = if (entry.customIconType == takagi.ru.monica.ui.icons.PASSWORD_ICON_TYPE_UPLOADED) {
                             takagi.ru.monica.ui.icons.rememberUploadedPasswordIcon(entry.customIconValue)
                         } else null
-                        val primaryAppPackageName = entry.primaryLinkedAppPackageName()
+                        val hasResolvedCustomIcon = simpleIcon != null || uploadedIcon != null
+                        val primaryAppPackageName = if (hasResolvedCustomIcon) {
+                            ""
+                        } else {
+                            entry.primaryLinkedAppPackageName()
+                        }
                         val appIcon = if (
+                            !hasResolvedCustomIcon &&
                             primaryAppPackageName.isNotBlank() &&
                             !takagi.ru.monica.autofill_ng.ui.isWebAddress(entry.website)
                         ) {
@@ -129,10 +136,11 @@ fun PasswordEntryCard(
                             title = entry.title,
                             appPackageName = primaryAppPackageName,
                             tintColor = MaterialTheme.colorScheme.primary,
-                            enabled = entry.customIconType == takagi.ru.monica.ui.icons.PASSWORD_ICON_TYPE_NONE
+                            enabled = !hasResolvedCustomIcon &&
+                                entry.customIconType == takagi.ru.monica.ui.icons.PASSWORD_ICON_TYPE_NONE
                         )
 
-                        val favicon = if (entry.website.isNotBlank()) {
+                        val favicon = if (!hasResolvedCustomIcon && entry.website.isNotBlank()) {
                             takagi.ru.monica.autofill_ng.ui.rememberFavicon(
                                 url = entry.website,
                                 enabled = autoMatchedSimpleIcon.resolved && autoMatchedSimpleIcon.slug == null
@@ -304,12 +312,23 @@ fun PasswordEntryCard(
                         null
                     }
                     val shouldHideDisplayLines = hideOtherContentWhenAuthenticator && authenticatorState != null
-                    val displayLines = if (
-                        passwordCardDisplayMode == takagi.ru.monica.data.PasswordCardDisplayMode.TITLE_ONLY || shouldHideDisplayLines
+                    val displayLines = remember(
+                        entry.username,
+                        entry.website,
+                        entry.notes,
+                        entry.updatedAt,
+                        passwordCardDisplayFields,
+                        passwordCardDisplayMode,
+                        shouldHideDisplayLines,
                     ) {
-                        emptyList()
-                    } else {
-                        resolvePasswordCardDisplayLines(entry, passwordCardDisplayFields).take(3)
+                        if (
+                            passwordCardDisplayMode == takagi.ru.monica.data.PasswordCardDisplayMode.TITLE_ONLY ||
+                            shouldHideDisplayLines
+                        ) {
+                            emptyList()
+                        } else {
+                            resolvePasswordCardDisplayLines(entry, passwordCardDisplayFields).take(3)
+                        }
                     }
                     displayLines.forEach { line ->
                         Row(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/viewmodel/PasswordGhostFilter.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/viewmodel/PasswordGhostFilter.kt
@@ -1,0 +1,43 @@
+package takagi.ru.monica.viewmodel
+
+/**
+ * Finds display-only ghost rows while keeping secret resolution off the common list path.
+ *
+ * A secret is resolved only for rows that share a ghost-group key with at least one
+ * other row. This preserves the old ghost semantics without decrypting every password
+ * in the vault just to render the list.
+ */
+internal fun <T> findGhostDisplayIds(
+    entries: List<T>,
+    idOf: (T) -> Long,
+    groupKeyOf: (T) -> String,
+    isPasswordMode: (T) -> Boolean,
+    shouldFilterGhost: (T) -> Boolean,
+    resolveSecret: (T) -> String,
+): Set<Long> {
+    if (entries.size <= 1) return emptySet()
+
+    val ghostIds = mutableSetOf<Long>()
+    entries.groupBy(groupKeyOf).values.forEach { group ->
+        if (group.size <= 1) return@forEach
+
+        // This is intentionally the only place where secrets are resolved. A normal
+        // list containing N unrelated rows therefore performs zero secret reads.
+        val resolvedSecrets = group.associate { entry ->
+            idOf(entry) to resolveSecret(entry)
+        }
+        if (resolvedSecrets.values.none(String::isNotBlank)) return@forEach
+
+        group.forEach { entry ->
+            if (
+                isPasswordMode(entry) &&
+                resolvedSecrets[idOf(entry)].isNullOrBlank() &&
+                shouldFilterGhost(entry)
+            ) {
+                ghostIds += idOf(entry)
+            }
+        }
+    }
+
+    return ghostIds
+}

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/viewmodel/PasswordViewModel.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/viewmodel/PasswordViewModel.kt
@@ -53,6 +53,7 @@ import takagi.ru.monica.repository.asMdbxBatchMove
 import takagi.ru.monica.repository.findMdbxReplicaTargetConflictIds
 import takagi.ru.monica.security.SecurityManager
 import takagi.ru.monica.security.SessionManager
+import takagi.ru.monica.rustcore.RustPasswordListCore
 import takagi.ru.monica.data.model.TotpData
 import takagi.ru.monica.data.ItemType
 import takagi.ru.monica.utils.KeePassCustomFieldData
@@ -500,17 +501,6 @@ class PasswordViewModel(
     init {
         restoreLastCategoryFilter()
         observeInvalidCustomCategoryFilter()
-        viewModelScope.launch(Dispatchers.IO) {
-            runCatching {
-                repairLegacyDetachedKeePassEntries()
-                repairLegacyOwnershipConflicts()
-            }.onFailure { error ->
-                Log.w("PasswordViewModel", "Password startup maintenance failed", error)
-            }
-        }
-        viewModelScope.launch(Dispatchers.Default) {
-            warmupBitwardenOfflineSecretCache()
-        }
     }
     
     fun getBitwardenFolders(vaultId: Long): Flow<List<BitwardenFolder>> {
@@ -624,7 +614,9 @@ class PasswordViewModel(
                 (filter as? CategoryFilter.Custom)?.categoryId?.let(::setOf).orEmpty()
             val baseFlow: Flow<List<PasswordEntry>> = if (query.isNotBlank()) {
                 // Extended search: query + custom fields, then apply current category filter in-memory.
-                val searchFlow = repository.searchPasswordEntries(query).map { baseResults ->
+                val searchFlow = rawAllPasswordsSource.map { allEntries ->
+                    val baseResults = RustPasswordListCore.filterEntries(allEntries, query)
+                        ?: allEntries.filter { matchesSearchQuery(it, query) }
                     val customFieldMatchIds = try {
                         customFieldRepository?.searchEntryIdsByFieldContent(query) ?: emptyList()
                     } catch (e: Exception) {
@@ -779,13 +771,12 @@ class PasswordViewModel(
                 } else {
                     dedupeExactEntries(filtered)
                 }
-                val decrypted = exactDeduped.map { entry ->
-                    entry.copy(password = inspectSecretState(entry).plainValueOrEmpty())
-                }
+                // Keep the stored ciphertext intact for explicit copy/move operations, but
+                // do not decrypt every row merely to render the password list.
                 if (shouldKeepRawDisplay) {
-                    decrypted
+                    exactDeduped
                 } else {
-                    filterGhostEntriesForDisplay(decrypted)
+                    filterGhostEntriesForDisplay(exactDeduped)
                 }
             }
         }
@@ -865,6 +856,41 @@ class PasswordViewModel(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList()
         )
+
+    // Startup repair and offline-secret warming are important, but neither is required
+    // to produce the first password-list frame. Defer them until the primary list
+    // metadata and categories have emitted once, then give the UI a short settling
+    // window before starting CPU/I/O-heavy maintenance.
+    init {
+        viewModelScope.launch {
+            combine(
+                passwordEntriesReady,
+                allPasswordsForUiReady,
+                categoriesReady,
+            ) { entriesReady, lookupReady, categoryListReady ->
+                entriesReady && lookupReady && categoryListReady
+            }
+                .filter { it }
+                .first()
+
+            kotlinx.coroutines.delay(1500L)
+
+            viewModelScope.launch(Dispatchers.IO) {
+                runCatching {
+                    repairLegacyDetachedKeePassEntries()
+                    repairLegacyOwnershipConflicts()
+                }.onFailure { error ->
+                    Log.w("PasswordViewModel", "Deferred password maintenance failed", error)
+                }
+            }
+            viewModelScope.launch(Dispatchers.Default) {
+                runCatching { warmupBitwardenOfflineSecretCache() }
+                    .onFailure { error ->
+                        Log.w("PasswordViewModel", "Deferred Bitwarden cache warmup failed", error)
+                    }
+            }
+        }
+    }
 
     // Lightweight archive stream for Vault V2. Password contents stay out of list state.
     private val archivedPasswordsForUiSource: Flow<List<PasswordEntry>> = rawArchivedPasswordsSource
@@ -1012,24 +1038,18 @@ class PasswordViewModel(
     }
 
     private fun filterGhostEntriesForDisplay(entries: List<PasswordEntry>): List<PasswordEntry> {
-        if (entries.size <= 1) return entries
-
-        val groups = entries.groupBy { buildGhostGroupKey(it) }
-        val ghostIds = mutableSetOf<Long>()
-
-        groups.values.forEach { group ->
-            if (group.size <= 1) return@forEach
-            if (!group.any { it.password.isNotBlank() }) return@forEach
-
-            group.forEach { entry ->
-                val isPasswordMode = entry.loginType.equals("PASSWORD", ignoreCase = true)
-                val shouldFilterGhost = !entry.isLocalOnlyEntry() || entry.hasOwnershipConflict()
-                if (isPasswordMode && entry.password.isBlank() && shouldFilterGhost) {
-                    ghostIds += entry.id
-                }
-            }
-        }
-
+        val ghostIds = findGhostDisplayIds(
+            entries = entries,
+            idOf = PasswordEntry::id,
+            groupKeyOf = ::buildGhostGroupKey,
+            isPasswordMode = { entry ->
+                entry.loginType.equals("PASSWORD", ignoreCase = true)
+            },
+            shouldFilterGhost = { entry ->
+                !entry.isLocalOnlyEntry() || entry.hasOwnershipConflict()
+            },
+            resolveSecret = { entry -> inspectSecretState(entry).plainValueOrEmpty() },
+        )
         if (ghostIds.isEmpty()) return entries
         return entries.filterNot { it.id in ghostIds }
     }

--- a/Monica for Android/app/src/test/java/takagi/ru/monica/viewmodel/PasswordGhostFilterTest.kt
+++ b/Monica for Android/app/src/test/java/takagi/ru/monica/viewmodel/PasswordGhostFilterTest.kt
@@ -1,0 +1,103 @@
+package takagi.ru.monica.viewmodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PasswordGhostFilterTest {
+    private data class Row(
+        val id: Long,
+        val group: String,
+        val passwordMode: Boolean = true,
+        val filterable: Boolean = true,
+        val secret: String = "",
+    )
+
+    @Test
+    fun unrelatedRowsDoNotResolveSecrets() {
+        var secretReads = 0
+        val rows = listOf(
+            Row(id = 1, group = "a", secret = "one"),
+            Row(id = 2, group = "b", secret = "two"),
+            Row(id = 3, group = "c", secret = "three"),
+        )
+
+        val result = findGhostDisplayIds(
+            entries = rows,
+            idOf = Row::id,
+            groupKeyOf = Row::group,
+            isPasswordMode = Row::passwordMode,
+            shouldFilterGhost = Row::filterable,
+            resolveSecret = {
+                secretReads += 1
+                it.secret
+            },
+        )
+
+        assertTrue(result.isEmpty())
+        assertEquals(0, secretReads)
+    }
+
+    @Test
+    fun duplicateGroupResolvesOnlyCandidatesAndFiltersBlankGhost() {
+        var secretReads = 0
+        val rows = listOf(
+            Row(id = 1, group = "same", secret = "real-secret"),
+            Row(id = 2, group = "same", secret = ""),
+            Row(id = 3, group = "other", secret = "never-read"),
+        )
+
+        val result = findGhostDisplayIds(
+            entries = rows,
+            idOf = Row::id,
+            groupKeyOf = Row::group,
+            isPasswordMode = Row::passwordMode,
+            shouldFilterGhost = Row::filterable,
+            resolveSecret = {
+                secretReads += 1
+                it.secret
+            },
+        )
+
+        assertEquals(setOf(2L), result)
+        assertEquals(2, secretReads)
+    }
+
+    @Test
+    fun blankLocalSiblingIsPreserved() {
+        val rows = listOf(
+            Row(id = 1, group = "same", secret = "real-secret"),
+            Row(id = 2, group = "same", filterable = false, secret = ""),
+        )
+
+        val result = findGhostDisplayIds(
+            entries = rows,
+            idOf = Row::id,
+            groupKeyOf = Row::group,
+            isPasswordMode = Row::passwordMode,
+            shouldFilterGhost = Row::filterable,
+            resolveSecret = Row::secret,
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun nonPasswordSiblingIsNeverTreatedAsGhostPassword() {
+        val rows = listOf(
+            Row(id = 1, group = "same", secret = "real-secret"),
+            Row(id = 2, group = "same", passwordMode = false, secret = ""),
+        )
+
+        val result = findGhostDisplayIds(
+            entries = rows,
+            idOf = Row::id,
+            groupKeyOf = Row::group,
+            isPasswordMode = Row::passwordMode,
+            shouldFilterGhost = Row::filterable,
+            resolveSecret = Row::secret,
+        )
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/Monica for Android/docs/performance-rust-refactor.zh-CN.md
+++ b/Monica for Android/docs/performance-rust-refactor.zh-CN.md
@@ -1,0 +1,109 @@
+# Monica Android 性能与 Rust 重构
+
+状态：**Phase 1 运行时接入中**。Rust 已不再只是隔离实验：Android 通过批量 JNI 调用使用无明文列表核心；同时优先删除 Kotlin 列表热路径中的无用全量解密。当前分支仍需真实设备 A/B 数据后才能声称具体性能提升。
+
+## 架构结论
+
+不把 Compose、导航、生命周期、Room、Android Keystore、生物识别和系统服务整体改写成 Rust。这些边界继续由 Kotlin/Android 管理。Rust 负责适合批量处理、确定性、平台无关的算法，例如列表元数据搜索/投影、来源感知去重、解析与合并逻辑。
+
+## 本轮已经落地的关键改动
+
+### 1. 普通密码列表取消全量登录密码解密
+
+旧路径在筛选/去重后，对每个可见 `PasswordEntry` 调用 `inspectSecretState(...).plainValueOrEmpty()`。卡片并不显示登录密码，因此这会把数据库失效、筛选切换和进入密码页都放大成 O(n) secret 解析。
+
+新路径：
+
+- 列表保留 Room 返回的原始密文，保证复制、移动、同步等显式命令仍有完整数据；
+- 普通渲染不再把整表变成密码明文；
+- 幽灵行过滤只对共享候选组解析 secret；单例条目零 secret 读取；
+- 智能去重继续只解析候选重复组；
+- 密码卡片、卡片展示字段和分组键均不读取登录密码。
+
+这里特意**不把 `password` 简单清空**：批量复制/移动会使用选中条目的存储密文做按需解密，清空会破坏跨存储复制语义。
+
+### 2. Rust 批量元数据搜索接入真实 Android 运行时
+
+新增 `rust-jni` cdylib 和 Kotlin `RustPasswordListCore` facade。一次查询只跨 JNI 一次，传入：
+
+- ID；
+- 标题；
+- 用户名；
+- 网站；
+- 应用名；
+- 包名；
+- 查询词。
+
+不会传入：登录密码、TOTP secret、银行卡敏感字段或其他 credential secret。Rust 返回匹配 ID；native 不可用时 Kotlin 自动回退。
+
+### 3. 首屏与维护任务分阶段
+
+原 `PasswordViewModel.init` 会在进入页面时并发启动：
+
+- KeePass 遗留绑定修复扫描；
+- ownership conflict 修复；
+- Bitwarden 离线 secret cache 全量预热。
+
+Bitwarden 预热会遍历绑定条目并解析密码，这与首屏数据库/Compose 同时抢 CPU。新方案先让密码列表元数据、全量 UI lookup 和分类首次就绪，再给 UI 一个短暂 settling window，之后才启动维护和缓存预热。功能保留，但不再作为首内容的前置竞争者。
+
+### 4. 发布链正式编译 Rust JNI
+
+- `Android.yml`：Release 构建前为 `arm64-v8a` 和 `armeabi-v7a` 构建 `libmonica_rust_jni.so`；
+- `Android-Preview.yml`：Preview/PR 构建同样带 Rust JNI，并监听 Rust 源码路径；
+- `Rust-Core.yml`：同时执行 `rust-core` 与 `rust-jni` 的 rustfmt/Clippy，core 单测继续执行；
+- R8 保留 JNI facade 的类名，避免静态 `Java_*` 导出在混淆后失联。
+
+## 安全边界
+
+- Keystore、主密码、biometric/session 逻辑不迁入 Rust；
+- JNI DTO 不含 credential secret；
+- 随机化密文不能充当 secret 相等指纹；
+- 如果未来引入 `secret_fingerprint`，只能使用写入/导入时产生的不可逆带密钥摘要；
+- IME 独立进程依赖 Room multi-instance invalidation，该能力不能为了性能移除。
+
+## 仍然值得继续的方向
+
+### UI 状态扇出
+
+`PasswordListContent` 仍然非常大，并同时订阅密码列表、全量 lookup、分类、搜索、认证、设置、KeePass/MDBX/Bitwarden、附件和传输状态。后续适合：
+
+- 收敛成稳定的屏幕级 `PasswordListUiState`；
+- 使用 lifecycle-aware Flow 收集；
+- 将同步/对话框/选择状态拆到独立组合边界；
+- 将仓库查询移出 Composable。
+
+### Room 元数据 projection
+
+`allPasswordsForUi` 目前仍由完整 `PasswordEntry` 映射并清空登录密码。长期应引入列表专用 projection/DTO，让 SQL 根本不读取不需要的敏感大字段，并减少对象复制和内存占用。
+
+### 图标链
+
+每张卡片仍可能涉及上传图标、Simple Icon、app icon、自动匹配与 favicon。应进一步形成单一来源状态机和稳定缓存，避免滚动时重复解析。
+
+## Rust FFI 规则
+
+- 每个快照/查询一次批量调用，禁止逐条 JNI；
+- Compose State 与回调不跨 FFI；
+- DTO 有明确边界，不包含密码；
+- native 失败必须有 Kotlin 回退；
+- Rust 结果必须保持输入顺序和现有搜索语义；
+- 只有真实 profiling 证明有 CPU 热点时才继续把算法迁入 Rust。
+
+## 验收门槛
+
+代码层：
+
+- Rust core 单测全绿；
+- rustfmt/Clippy 全绿；
+- Android JVM 单测全绿；
+- Kotlin 编译和完整 APK 构建通过；
+- APK 内实际包含对应 ABI 的 `libmonica_rust_jni.so`；
+- 批量复制/移动、详情、搜索、分类、混合 KeePass/MDBX/Bitwarden 视图语义不回退。
+
+设备层：
+
+- 同一设备、同一数据库、同一配置做冷进程 A/B；
+- 记录解锁到首内容、p50/p95/p99 帧时间、jank、Java/native heap 和 APK 体积；
+- 在没有设备测量前不写“提升 X 倍”之类结论。
+
+推荐控制组：同一 commit/buildType 做一份禁用 Rust runtime 的 APK，与启用 Rust 的 APK 放在等价新实例/克隆环境中比较；这样才能把 Rust 收益、启动维护调度收益和历史应用状态差异拆开。

--- a/Monica for Android/rust-core/Cargo.toml
+++ b/Monica for Android/rust-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "monica-password-list-core"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.74"
+publish = false
+license = "GPL-3.0-only"
+description = "Secret-free password-list projection core for Monica"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["rlib"]
+
+[dependencies]

--- a/Monica for Android/rust-core/README.md
+++ b/Monica for Android/rust-core/README.md
@@ -1,0 +1,49 @@
+# Monica Password List Rust Core
+
+这是 Monica Android 性能重构中的 Rust 运行时边界：**密码列表的无明文元数据筛选、投影与保守去重**。
+
+## 当前落地方式
+
+密码列表原先会把筛选后的条目逐条解析/解密，再把结果送进 Compose。列表卡片实际只依赖标题、用户名、网站、备注、更新时间、来源与图标，因此登录密码不应成为列表渲染的前置工作。
+
+当前重构采用以下边界：
+
+1. Room 仍可返回条目原始密文，以保证复制、移动、同步等显式操作语义不变；
+2. 普通密码列表不再为每一行解析登录密码；只有幽灵条目判定、智能去重等确实需要比较 secret 的候选小组才按需解析；
+3. 搜索时通过 `rust-jni` 一次批量传入 ID、标题、用户名、网站、应用名和包名，由本 crate 完成元数据筛选；
+4. JNI 不可用时 Kotlin 自动回退，不阻塞应用功能；
+5. Compose、生命周期、Room、Android Keystore、生物识别及存储 provider 继续留在 Kotlin/Android。
+
+## 安全边界
+
+`PasswordListRecord` 没有密码字段。Android JNI 运行时也不会把 `PasswordEntry.password`、TOTP secret、银行卡敏感字段等传入 Rust。
+
+可选的 `secret_fingerprint` 只能是 Android 数据层在写入/导入时产生的、不可逆的带密钥摘要；不能传明文，也不能把随机化密文当成指纹。
+
+去重采用保守原则：
+
+- 没有明确来源身份的本地条目永不合并；
+- 未知指纹不视为相同；
+- 同一副本组、同一存储目标内出现多条记录时，视为用户有意保存的多密码兄弟条目；
+- 只有满足既定来源身份和 secret 语义的条目才允许折叠。
+
+## FFI 规则
+
+Android 接入位于相邻的 `../rust-jni` crate。规则如下：
+
+- 一次列表快照/搜索只做一次批量 JNI 调用，禁止逐行跨 FFI；
+- FFI DTO 只包含展示/检索元数据；
+- native 加载或调用失败必须回退 Kotlin；
+- R8 必须保留 `takagi.ru.monica.rustcore.RustPasswordListCore`，因为 JNI 使用静态 `Java_*` 导出符号；
+- Release/Preview CI 必须为项目支持的 ABI 生成 `libmonica_rust_jni.so` 后再执行 Gradle 打包。
+
+## 校验
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-targets --all-features
+
+cargo fmt --manifest-path ../rust-jni/Cargo.toml --all -- --check
+cargo clippy --manifest-path ../rust-jni/Cargo.toml --all-targets --all-features -- -D warnings
+```

--- a/Monica for Android/rust-core/src/lib.rs
+++ b/Monica for Android/rust-core/src/lib.rs
@@ -1,0 +1,554 @@
+#![forbid(unsafe_code)]
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+/// Describes why two rows may represent the same logical credential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IdentityKind {
+    /// A stable identifier for one external object, such as a Bitwarden cipher
+    /// ID or KeePass entry UUID.
+    ExternalObject,
+    /// A Monica replica group copied to multiple storage targets.
+    ReplicaGroup,
+}
+
+/// Explicit identity used for conservative display deduplication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollapseIdentity {
+    pub kind: IdentityKind,
+    pub value: String,
+}
+
+/// Secret-free metadata required to build Monica's password list.
+///
+/// This type intentionally has no password field. `secret_fingerprint`, when
+/// present, must be a non-reversible keyed digest produced by the Android data
+/// layer at write/import time. Never pass plaintext or ciphertext as a
+/// fingerprint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PasswordListRecord {
+    pub id: i64,
+    pub title: String,
+    pub username: String,
+    pub website: String,
+    pub app_name: String,
+    pub app_package_name: String,
+    pub notes_preview: String,
+    pub collapse_identity: Option<CollapseIdentity>,
+    pub storage_target_key: Option<String>,
+    pub secret_fingerprint: Option<String>,
+    pub is_favorite: bool,
+    pub updated_at_millis: i64,
+}
+
+/// Stable, secret-free row consumed by the Compose password list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PasswordListProjection {
+    pub id: i64,
+    pub title: String,
+    pub username: String,
+    pub website: String,
+    pub app_name: String,
+    pub app_package_name: String,
+    pub notes_preview: String,
+    pub is_favorite: bool,
+    pub updated_at_millis: i64,
+}
+
+impl From<&PasswordListRecord> for PasswordListProjection {
+    fn from(record: &PasswordListRecord) -> Self {
+        Self {
+            id: record.id,
+            title: record.title.clone(),
+            username: record.username.clone(),
+            website: record.website.clone(),
+            app_name: record.app_name.clone(),
+            app_package_name: record.app_package_name.clone(),
+            notes_preview: record.notes_preview.clone(),
+            is_favorite: record.is_favorite,
+            updated_at_millis: record.updated_at_millis,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProjectionOptions {
+    pub collapse_known_replicas: bool,
+}
+
+impl Default for ProjectionOptions {
+    fn default() -> Self {
+        Self {
+            collapse_known_replicas: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ProjectionStats {
+    pub input_count: usize,
+    pub matched_count: usize,
+    pub filtered_out_count: usize,
+    pub collapsed_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionResult {
+    pub items: Vec<PasswordListProjection>,
+    pub stats: ProjectionStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct NormalizedIdentity {
+    kind: IdentityKind,
+    value: String,
+}
+
+#[derive(Clone, Copy)]
+struct Candidate<'a> {
+    original_index: usize,
+    record: &'a PasswordListRecord,
+}
+
+/// Filters and projects one complete password-list snapshot in a single batch.
+///
+/// Deduplication is deliberately conservative:
+///
+/// - identity-less local rows are always preserved;
+/// - rows with unknown secret fingerprints are preserved rather than guessed;
+/// - multiple rows in the same replica group and storage target are treated as
+///   intentional sibling credentials and are never collapsed;
+/// - only rows with the same explicit identity and the same known fingerprint
+///   are eligible for collapsing.
+///
+/// The result retains the original relative order of the selected rows.
+#[must_use]
+pub fn project_password_list(
+    records: &[PasswordListRecord],
+    query: &str,
+    options: ProjectionOptions,
+) -> ProjectionResult {
+    let normalized_query = query.trim().to_lowercase();
+    let matched: Vec<Candidate<'_>> = records
+        .iter()
+        .enumerate()
+        .filter(|(_, record)| record_matches_query(record, &normalized_query))
+        .map(|(original_index, record)| Candidate {
+            original_index,
+            record,
+        })
+        .collect();
+
+    let matched_count = matched.len();
+    let mut selected = if options.collapse_known_replicas {
+        collapse_candidates(matched)
+    } else {
+        matched
+    };
+
+    selected.sort_by_key(|candidate| candidate.original_index);
+    let items = selected
+        .into_iter()
+        .map(|candidate| PasswordListProjection::from(candidate.record))
+        .collect::<Vec<_>>();
+
+    ProjectionResult {
+        stats: ProjectionStats {
+            input_count: records.len(),
+            matched_count,
+            filtered_out_count: records.len().saturating_sub(matched_count),
+            collapsed_count: matched_count.saturating_sub(items.len()),
+        },
+        items,
+    }
+}
+
+fn collapse_candidates<'a>(candidates: Vec<Candidate<'a>>) -> Vec<Candidate<'a>> {
+    let mut independent = Vec::new();
+    let mut groups: HashMap<NormalizedIdentity, Vec<Candidate<'a>>> = HashMap::new();
+
+    for candidate in candidates {
+        let Some(identity) = normalized_identity(candidate.record) else {
+            independent.push(candidate);
+            continue;
+        };
+        groups.entry(identity).or_default().push(candidate);
+    }
+
+    let mut selected = independent;
+    for (identity, group) in groups {
+        match identity.kind {
+            IdentityKind::ExternalObject => {
+                selected.extend(collapse_by_known_fingerprint(group));
+            }
+            IdentityKind::ReplicaGroup => {
+                selected.extend(collapse_replica_group(group));
+            }
+        }
+    }
+    selected
+}
+
+fn collapse_replica_group<'a>(group: Vec<Candidate<'a>>) -> Vec<Candidate<'a>> {
+    let mut by_target: HashMap<String, Vec<Candidate<'a>>> = HashMap::new();
+    let mut target_unknown = Vec::new();
+
+    for candidate in group {
+        let target = candidate
+            .record
+            .storage_target_key
+            .as_deref()
+            .map(normalize_key)
+            .filter(|value| !value.is_empty());
+        if let Some(target) = target {
+            by_target.entry(target).or_default().push(candidate);
+        } else {
+            target_unknown.push(candidate);
+        }
+    }
+
+    let mut selected = target_unknown;
+    let mut singleton_targets = Vec::new();
+    for target_rows in by_target.into_values() {
+        if target_rows.len() > 1 {
+            // Multiple rows in one target may be intentional sibling passwords.
+            selected.extend(target_rows);
+        } else {
+            singleton_targets.extend(target_rows);
+        }
+    }
+    selected.extend(collapse_by_known_fingerprint(singleton_targets));
+    selected
+}
+
+fn collapse_by_known_fingerprint<'a>(group: Vec<Candidate<'a>>) -> Vec<Candidate<'a>> {
+    let mut selected = Vec::new();
+    let mut best_by_fingerprint: HashMap<String, Candidate<'a>> = HashMap::new();
+
+    for candidate in group {
+        let fingerprint = candidate
+            .record
+            .secret_fingerprint
+            .as_deref()
+            .map(normalize_fingerprint)
+            .filter(|value| !value.is_empty());
+
+        let Some(fingerprint) = fingerprint else {
+            // Unknown is not proof of equality. Preserve the row.
+            selected.push(candidate);
+            continue;
+        };
+
+        match best_by_fingerprint.get_mut(&fingerprint) {
+            Some(best) => {
+                if record_quality_cmp(candidate.record, best.record) == Ordering::Greater {
+                    *best = candidate;
+                }
+            }
+            None => {
+                best_by_fingerprint.insert(fingerprint, candidate);
+            }
+        }
+    }
+
+    selected.extend(best_by_fingerprint.into_values());
+    selected
+}
+
+fn normalized_identity(record: &PasswordListRecord) -> Option<NormalizedIdentity> {
+    let identity = record.collapse_identity.as_ref()?;
+    let value = normalize_key(&identity.value);
+    if value.is_empty() {
+        return None;
+    }
+    Some(NormalizedIdentity {
+        kind: identity.kind,
+        value,
+    })
+}
+
+fn record_matches_query(record: &PasswordListRecord, normalized_query: &str) -> bool {
+    if normalized_query.is_empty() {
+        return true;
+    }
+
+    [
+        record.title.as_str(),
+        record.username.as_str(),
+        record.website.as_str(),
+        record.app_name.as_str(),
+        record.app_package_name.as_str(),
+        record.notes_preview.as_str(),
+    ]
+    .into_iter()
+    .any(|field| contains_case_insensitive(field, normalized_query))
+}
+
+fn contains_case_insensitive(value: &str, normalized_query: &str) -> bool {
+    if normalized_query.is_empty() {
+        return true;
+    }
+
+    if value.is_ascii() && normalized_query.is_ascii() {
+        let query = normalized_query.as_bytes();
+        return value
+            .as_bytes()
+            .windows(query.len())
+            .any(|window| window.eq_ignore_ascii_case(query));
+    }
+
+    value.to_lowercase().contains(normalized_query)
+}
+
+fn normalize_key(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+fn normalize_fingerprint(value: &str) -> String {
+    value.trim().to_owned()
+}
+
+fn record_quality_cmp(left: &PasswordListRecord, right: &PasswordListRecord) -> Ordering {
+    left.is_favorite
+        .cmp(&right.is_favorite)
+        .then_with(|| non_empty_field_count(left).cmp(&non_empty_field_count(right)))
+        .then_with(|| text_richness(left).cmp(&text_richness(right)))
+        .then_with(|| left.updated_at_millis.cmp(&right.updated_at_millis))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+fn non_empty_field_count(record: &PasswordListRecord) -> usize {
+    [
+        record.title.as_str(),
+        record.username.as_str(),
+        record.website.as_str(),
+        record.app_name.as_str(),
+        record.app_package_name.as_str(),
+        record.notes_preview.as_str(),
+    ]
+    .into_iter()
+    .filter(|value| !value.trim().is_empty())
+    .count()
+}
+
+fn text_richness(record: &PasswordListRecord) -> usize {
+    record.title.len()
+        + record.username.len()
+        + record.website.len()
+        + record.app_name.len()
+        + record.app_package_name.len()
+        + record.notes_preview.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(id: i64, title: &str) -> PasswordListRecord {
+        PasswordListRecord {
+            id,
+            title: title.to_owned(),
+            username: String::new(),
+            website: String::new(),
+            app_name: String::new(),
+            app_package_name: String::new(),
+            notes_preview: String::new(),
+            collapse_identity: None,
+            storage_target_key: None,
+            secret_fingerprint: None,
+            is_favorite: false,
+            updated_at_millis: 0,
+        }
+    }
+
+    fn identity(kind: IdentityKind, value: &str) -> CollapseIdentity {
+        CollapseIdentity {
+            kind,
+            value: value.to_owned(),
+        }
+    }
+
+    fn ids(result: &ProjectionResult) -> Vec<i64> {
+        result.items.iter().map(|item| item.id).collect()
+    }
+
+    #[test]
+    fn blank_query_preserves_order() {
+        let records = vec![record(10, "first"), record(20, "second")];
+
+        let result = project_password_list(&records, "  ", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![10, 20]);
+        assert_eq!(result.stats.input_count, 2);
+        assert_eq!(result.stats.matched_count, 2);
+        assert_eq!(result.stats.filtered_out_count, 0);
+        assert_eq!(result.stats.collapsed_count, 0);
+    }
+
+    #[test]
+    fn search_is_case_insensitive_across_display_metadata() {
+        let mut github = record(1, "GitHub");
+        github.app_package_name = "com.github.android".to_owned();
+        let mut bank = record(2, "Bank");
+        bank.website = "example.cn".to_owned();
+        let records = vec![github, bank];
+
+        let result = project_password_list(&records, "GITHUB", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1]);
+        assert_eq!(result.stats.filtered_out_count, 1);
+    }
+
+    #[test]
+    fn unicode_search_uses_lowercase_fallback() {
+        let records = vec![record(1, "MÜNCHEN"), record(2, "Berlin")];
+
+        let result = project_password_list(&records, "münchen", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1]);
+    }
+
+    #[test]
+    fn local_duplicates_are_never_collapsed() {
+        let records = vec![record(1, "same"), record(2, "same")];
+
+        let result = project_password_list(&records, "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1, 2]);
+        assert_eq!(result.stats.collapsed_count, 0);
+    }
+
+    #[test]
+    fn blank_identity_is_treated_as_independent() {
+        let mut first = record(1, "same");
+        first.collapse_identity = Some(identity(IdentityKind::ExternalObject, "   "));
+        let mut second = record(2, "same");
+        second.collapse_identity = Some(identity(IdentityKind::ExternalObject, "   "));
+
+        let result = project_password_list(&[first, second], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1, 2]);
+    }
+
+    #[test]
+    fn external_rows_with_same_known_fingerprint_collapse() {
+        let mut older = record(1, "GitHub");
+        older.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+        older.secret_fingerprint = Some("hmac:abc".to_owned());
+        older.updated_at_millis = 100;
+
+        let mut richer = record(2, "GitHub");
+        richer.collapse_identity =
+            Some(identity(IdentityKind::ExternalObject, " BW:VAULT:CIPHER "));
+        richer.secret_fingerprint = Some(" hmac:abc ".to_owned());
+        richer.username = "octocat".to_owned();
+        richer.is_favorite = true;
+        richer.updated_at_millis = 200;
+
+        let result = project_password_list(&[older, richer], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![2]);
+        assert_eq!(result.stats.collapsed_count, 1);
+    }
+
+    #[test]
+    fn external_rows_with_different_fingerprints_remain_distinct() {
+        let mut first = record(1, "GitHub");
+        first.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+        first.secret_fingerprint = Some("hmac:first".to_owned());
+        let mut second = record(2, "GitHub");
+        second.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+        second.secret_fingerprint = Some("hmac:second".to_owned());
+
+        let result = project_password_list(&[first, second], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1, 2]);
+    }
+
+    #[test]
+    fn unknown_fingerprints_are_not_guessed_equal() {
+        let mut first = record(1, "GitHub");
+        first.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+        let mut second = record(2, "GitHub");
+        second.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+
+        let result = project_password_list(&[first, second], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1, 2]);
+        assert_eq!(result.stats.collapsed_count, 0);
+    }
+
+    #[test]
+    fn replica_siblings_in_the_same_target_are_preserved() {
+        let mut first = record(1, "GitHub");
+        first.collapse_identity = Some(identity(IdentityKind::ReplicaGroup, "replica-1"));
+        first.storage_target_key = Some("local".to_owned());
+        first.secret_fingerprint = Some("hmac:first".to_owned());
+        let mut second = record(2, "GitHub");
+        second.collapse_identity = Some(identity(IdentityKind::ReplicaGroup, "replica-1"));
+        second.storage_target_key = Some("local".to_owned());
+        second.secret_fingerprint = Some("hmac:first".to_owned());
+
+        let result = project_password_list(&[first, second], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1, 2]);
+    }
+
+    #[test]
+    fn singleton_target_replicas_with_same_fingerprint_collapse() {
+        let mut local = record(1, "GitHub");
+        local.collapse_identity = Some(identity(IdentityKind::ReplicaGroup, "replica-1"));
+        local.storage_target_key = Some("local".to_owned());
+        local.secret_fingerprint = Some("hmac:same".to_owned());
+
+        let mut remote = record(2, "GitHub");
+        remote.collapse_identity = Some(identity(IdentityKind::ReplicaGroup, "replica-1"));
+        remote.storage_target_key = Some("bitwarden:vault".to_owned());
+        remote.secret_fingerprint = Some("hmac:same".to_owned());
+        remote.is_favorite = true;
+
+        let result = project_password_list(&[local, remote], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![2]);
+        assert_eq!(result.stats.collapsed_count, 1);
+    }
+
+    #[test]
+    fn singleton_target_replicas_with_different_fingerprints_remain_distinct() {
+        let mut local = record(1, "GitHub");
+        local.collapse_identity = Some(identity(IdentityKind::ReplicaGroup, "replica-1"));
+        local.storage_target_key = Some("local".to_owned());
+        local.secret_fingerprint = Some("hmac:first".to_owned());
+
+        let mut remote = record(2, "GitHub");
+        remote.collapse_identity = Some(identity(IdentityKind::ReplicaGroup, "replica-1"));
+        remote.storage_target_key = Some("bitwarden:vault".to_owned());
+        remote.secret_fingerprint = Some("hmac:second".to_owned());
+
+        let result = project_password_list(&[local, remote], "", ProjectionOptions::default());
+
+        assert_eq!(ids(&result), vec![1, 2]);
+    }
+
+    #[test]
+    fn collapsing_can_be_disabled() {
+        let mut first = record(1, "GitHub");
+        first.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+        first.secret_fingerprint = Some("hmac:same".to_owned());
+        let mut second = record(2, "GitHub");
+        second.collapse_identity = Some(identity(IdentityKind::ExternalObject, "bw:vault:cipher"));
+        second.secret_fingerprint = Some("hmac:same".to_owned());
+
+        let result = project_password_list(
+            &[first, second],
+            "",
+            ProjectionOptions {
+                collapse_known_replicas: false,
+            },
+        );
+
+        assert_eq!(ids(&result), vec![1, 2]);
+        assert_eq!(result.stats.collapsed_count, 0);
+    }
+}

--- a/Monica for Android/rust-jni/Cargo.toml
+++ b/Monica for Android/rust-jni/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "monica-rust-jni"
+version = "0.2.0"
+edition = "2021"
+rust-version = "1.74"
+publish = false
+license = "GPL-3.0-only"
+description = "Android JNI bridge for Monica password-list runtime core"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+jni = "0.21"
+monica-password-list-core = { path = "../rust-core" }

--- a/Monica for Android/rust-jni/README.md
+++ b/Monica for Android/rust-jni/README.md
@@ -1,0 +1,23 @@
+# Monica Android Rust JNI
+
+`rust-jni` 是 Android 与 `rust-core` 之间的窄桥接层。
+
+当前运行时接入的是密码列表元数据搜索。Kotlin 一次性传入平行数组：ID、标题、用户名、网站、应用名、包名和查询词；Rust 返回保持原顺序的匹配 ID。登录密码、TOTP secret、支付信息等敏感值不进入 JNI。
+
+## 回退
+
+`RustPasswordListCore` 会懒加载 `libmonica_rust_jni.so` 并执行 native self-test。如果动态库缺失或调用失败，调用方返回 `null` 并使用 Kotlin 元数据筛选，应用功能不会因 Rust 不可用而失效。
+
+## Android 构建
+
+```bash
+rustup target add aarch64-linux-android armv7-linux-androideabi
+cargo install cargo-ndk --locked
+cargo ndk \
+  -t arm64-v8a \
+  -t armeabi-v7a \
+  -o ../app/src/main/jniLibs \
+  build --release
+```
+
+生成的 `.so` 是构建产物，不应手工提交。正式 Release 和 Preview 工作流会在 Gradle 打包前执行同样的 native 构建。

--- a/Monica for Android/rust-jni/src/lib.rs
+++ b/Monica for Android/rust-jni/src/lib.rs
@@ -1,0 +1,161 @@
+#![allow(non_snake_case)]
+
+use jni::objects::{JClass, JLongArray, JObjectArray, JString};
+use jni::sys::{jboolean, jlongArray, jstring, JNI_FALSE, JNI_TRUE};
+use jni::JNIEnv;
+use monica_password_list_core::{project_password_list, PasswordListRecord, ProjectionOptions};
+
+const RUST_CORE_VERSION: &str = "monica-password-list-core/0.2.0-runtime";
+
+struct MetadataArrays<'local, 'borrow> {
+    ids: &'borrow JLongArray<'local>,
+    titles: &'borrow JObjectArray<'local>,
+    usernames: &'borrow JObjectArray<'local>,
+    websites: &'borrow JObjectArray<'local>,
+    app_names: &'borrow JObjectArray<'local>,
+    app_package_names: &'borrow JObjectArray<'local>,
+}
+
+#[no_mangle]
+pub extern "system" fn Java_takagi_ru_monica_rustcore_RustPasswordListCore_nativeVersion(
+    env: JNIEnv,
+    _class: JClass,
+) -> jstring {
+    match env.new_string(RUST_CORE_VERSION) {
+        Ok(value) => value.into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_takagi_ru_monica_rustcore_RustPasswordListCore_nativeSelfTest(
+    _env: JNIEnv,
+    _class: JClass,
+) -> jboolean {
+    let rows = vec![PasswordListRecord {
+        id: 101,
+        title: "GitHub".to_owned(),
+        username: "octocat".to_owned(),
+        website: "https://github.com".to_owned(),
+        app_name: String::new(),
+        app_package_name: String::new(),
+        notes_preview: String::new(),
+        collapse_identity: None,
+        storage_target_key: None,
+        secret_fingerprint: None,
+        is_favorite: true,
+        updated_at_millis: 1,
+    }];
+    let projected = project_password_list(
+        &rows,
+        "github",
+        ProjectionOptions {
+            collapse_known_replicas: false,
+        },
+    );
+    if projected.items.len() == 1 && projected.items[0].id == 101 {
+        JNI_TRUE
+    } else {
+        JNI_FALSE
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_takagi_ru_monica_rustcore_RustPasswordListCore_nativeFilterIds(
+    mut env: JNIEnv,
+    _class: JClass,
+    ids: JLongArray,
+    titles: JObjectArray,
+    usernames: JObjectArray,
+    websites: JObjectArray,
+    app_names: JObjectArray,
+    app_package_names: JObjectArray,
+    query: JString,
+) -> jlongArray {
+    let arrays = MetadataArrays {
+        ids: &ids,
+        titles: &titles,
+        usernames: &usernames,
+        websites: &websites,
+        app_names: &app_names,
+        app_package_names: &app_package_names,
+    };
+    filter_ids(&mut env, arrays, &query).unwrap_or(std::ptr::null_mut())
+}
+
+fn filter_ids(
+    env: &mut JNIEnv,
+    arrays: MetadataArrays<'_, '_>,
+    query: &JString,
+) -> Option<jlongArray> {
+    let len = env.get_array_length(arrays.ids).ok()? as usize;
+    for array in [
+        arrays.titles,
+        arrays.usernames,
+        arrays.websites,
+        arrays.app_names,
+        arrays.app_package_names,
+    ] {
+        if env.get_array_length(array).ok()? as usize != len {
+            return None;
+        }
+    }
+
+    let mut id_values = vec![0_i64; len];
+    env.get_long_array_region(arrays.ids, 0, &mut id_values)
+        .ok()?;
+    let titles = read_string_array(env, arrays.titles, len)?;
+    let usernames = read_string_array(env, arrays.usernames, len)?;
+    let websites = read_string_array(env, arrays.websites, len)?;
+    let app_names = read_string_array(env, arrays.app_names, len)?;
+    let app_package_names = read_string_array(env, arrays.app_package_names, len)?;
+    let query: String = env.get_string(query).ok()?.into();
+
+    let records = (0..len)
+        .map(|index| PasswordListRecord {
+            id: id_values[index],
+            title: titles[index].clone(),
+            username: usernames[index].clone(),
+            website: websites[index].clone(),
+            app_name: app_names[index].clone(),
+            app_package_name: app_package_names[index].clone(),
+            notes_preview: String::new(),
+            collapse_identity: None,
+            storage_target_key: None,
+            secret_fingerprint: None,
+            is_favorite: false,
+            updated_at_millis: 0,
+        })
+        .collect::<Vec<_>>();
+
+    let projected = project_password_list(
+        &records,
+        &query,
+        ProjectionOptions {
+            collapse_known_replicas: false,
+        },
+    );
+    let selected_ids = projected
+        .items
+        .iter()
+        .map(|item| item.id)
+        .collect::<Vec<_>>();
+    let output = env.new_long_array(selected_ids.len() as i32).ok()?;
+    env.set_long_array_region(&output, 0, &selected_ids).ok()?;
+    Some(output.into_raw())
+}
+
+fn read_string_array(env: &mut JNIEnv, array: &JObjectArray, len: usize) -> Option<Vec<String>> {
+    let mut values = Vec::with_capacity(len);
+    for index in 0..len {
+        let object = env.get_object_array_element(array, index as i32).ok()?;
+        if object.is_null() {
+            values.push(String::new());
+            continue;
+        }
+        let string = JString::from(object);
+        let value: String = env.get_string(&string).ok()?.into();
+        values.push(value);
+    }
+    Some(values)
+}


### PR DESCRIPTION
### **背景**


在密码数据量较大时，Android 端密码列表首屏加载存在明显的性能问题。

原有实现会在密码列表数据流中对大量密码条目逐条执行解密，同时启动阶段还会执行 Bitwarden 离线缓存预热、遗留数据修复等任务。这些操作会与数据库读取、Compose 首屏渲染竞争 CPU 和 I/O，导致部分数据量较大的用户进入密码列表时出现较长等待。

本 PR 对密码列表的关键运行时路径进行了重构，并引入一个独立的 Rust 核心用于适合批处理的纯数据逻辑。

### 主要改动
**1. 移除密码列表首屏的全量密码解密**

密码列表本身并不需要显示登录密码，因此不再为了渲染列表而提前解密所有密码。

密码字段仍然保留原始加密数据，以保证复制、移动、导出等现有功能语义不变；真正需要明文密码时仍然按照原有方式按需解密。

这能够显著减少大数据量场景下的解密次数。

**2. 优化幽灵条目过滤**

原来的幽灵条目判断依赖密码明文，因此可能触发大量无意义解密。

现在会先根据非敏感元数据筛选出可能存在冲突的候选组，只对真正需要参与判断的少量条目解析密码。

对于不存在重复候选的普通条目，不再执行密码解密。

**3. 延后非首屏必要任务**

将以下任务从密码列表首屏关键路径中移出：

Bitwarden 离线 Secret 缓存预热
部分遗留数据修复扫描
与首批密码列表显示无直接关系的维护任务

这些功能仍然保留，只是不再与首屏加载同时竞争资源。

**4. 引入 Rust 密码列表核心**

新增 rust-core，负责适合 Rust 批处理的纯数据逻辑，例如：

密码列表元数据投影
搜索
去重相关逻辑
后续可以继续复用的批量数据处理

Rust 核心保持：

不依赖 Android API
#![forbid(unsafe_code)]
可独立测试
不接收密码明文、TOTP Secret、银行卡信息等敏感数据
**5. Android JNI 批处理桥接**

新增 rust-jni。

Android 端不会逐条调用 JNI，而是一次传递一个列表快照，让 Rust 批量处理后返回结果。

传入 Rust 的内容仅包括搜索所需的非敏感字段，例如：

ID
标题
用户名
网站
应用名称等元数据

密码、TOTP、卡号、私钥等 Secret 不进入 Rust FFI。

JNI 不可用时仍保留 Kotlin fallback。

6. 优化密码卡片图标加载

对密码卡片的图标 fallback 链进行了按需处理。

当已经能够确定图标来源时，不再继续执行无意义的 App 图标、自动匹配或 favicon fallback 解析，从而减少列表滚动过程中的额外工作。

7. 构建与 CI

增加 Rust Core / JNI 的 CI 检查，并在 Android 构建流程中编译对应的 Rust native library。

包括：

cargo fmt
cargo clippy
Rust 单元测试
Android arm64 Rust 交叉编译
Kotlin 编译
Android APK 构建
性能效果

在包含相同密码数据的实际设备测试中，原版本进入密码列表时曾出现约十几秒甚至更长的等待。

重构后的测试版本首批密码列表能够明显更快显示，页面切换和列表滚动也更加流畅。

具体性能提升会受到：

密码数量
数据来源
Bitwarden / KeePass / MDBX 数据情况
设备性能
缓存状态

等因素影响，因此这里不将单台设备的数据作为固定 benchmark。

兼容性原则

本 PR 尽量避免修改安全和存储边界。

没有将以下 Android 平台相关逻辑迁移到 Rust：

Android Keystore
Biometric
EncryptedSharedPreferences
Room
WorkManager
IME / 多进程数据库机制
Android 生命周期

密码数据库格式也没有因为本次性能优化发生迁移。

测试情况

已验证：

Rust Core 单元测试通过
Rust fmt / clippy 通过
Rust JNI arm64 交叉编译通过
Kotlin 全量编译通过
Android Debug APK 构建通过
APK 中 Rust JNI .so 存在并能够正常加载
实际设备密码列表加载、页面切换和滚动正常

仓库现有 JVM 测试中存在一组主分支本身已有的失败项，本次重构与 main 对照后未发现新增失败测试。

后续

这次 Rust 化主要集中在已经能够明确证明收益的批量纯数据路径。

后续如果 benchmark 能证明收益，可以继续考虑将以下计算密集型任务逐步迁移到 Rust：

大规模导入/解析
Merge / Conflict 计算
KeePass / MDBX 部分纯数据转换
大批量 hash / fingerprint

不会为了增加 Rust 占比而迁移 Android 平台、安全或生命周期相关代码。