### PR TITLE
fix: localize CSV import error message, pad two more bottom bars

### DIFF
--- a/Monica Android发行说明.md
+++ b/Monica Android发行说明.md
@@ -4,6 +4,7 @@
 
 ### 简要
 
+- 感谢 [@tommynok](https://github.com/tommynok) 贡献 [#134](https://github.com/Monica-Pass/Monica/pull/134)：修复导入页面底部操作栏被系统导航栏遮挡的问题，CSV 导入失败提示现已适配全部八种应用语言。
 - 感谢 [@tommynok](https://github.com/tommynok) 贡献 [#131](https://github.com/Monica-Pass/Monica/pull/131)：补全俄语翻译、安全问题本地化，并改善较长文字的布局。
 - 修复 [#128](https://github.com/Monica-Pass/Monica/issues/128)：分组样式选项和 MDBX 管理器随应用语言显示，补全英文、中文和俄语文案，切换语言后及时刷新。
 - 新增卡包卡叠，支持组合收纳与上下翻阅。
@@ -44,6 +45,7 @@
 
 ### Summary
 
+- Thanks to [@tommynok](https://github.com/tommynok) for [#134](https://github.com/Monica-Pass/Monica/pull/134): the import action bar now respects system navigation insets, and CSV import failure messages support all eight app languages.
 - Thanks to [@tommynok](https://github.com/tommynok) for [#131](https://github.com/Monica-Pass/Monica/pull/131): expanded Russian translations, localized security questions, and improved layouts for longer labels.
 - Fixed [#128](https://github.com/Monica-Pass/Monica/issues/128): grouping options and the MDBX manager follow the app language, with English, Chinese, and Russian text that refreshes after language changes.
 - Added wallet card stacks for grouped storage and vertical browsing.

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/DedupEngineScreen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/DedupEngineScreen.kt
@@ -854,7 +854,8 @@ private fun MergeBottomBar(uiState: DedupEngineUiState, onReviewAndMerge: () -> 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .navigationBarsPadding(),
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Button(

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/ImportDataScreen.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/ui/screens/ImportDataScreen.kt
@@ -250,7 +250,9 @@ fun ImportDataScreen(
                 shadowElevation = 8.dp
             ) {
                 Column(
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .navigationBarsPadding(),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     // 导入按钮

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/util/DataExportImportManager.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/util/DataExportImportManager.kt
@@ -10,6 +10,7 @@ import takagi.ru.monica.data.model.BankCardData
 import takagi.ru.monica.data.model.NoteData
 import takagi.ru.monica.data.model.SecureCustomField
 import takagi.ru.monica.data.model.SecureCustomFieldType
+import takagi.ru.monica.utils.AppLocaleStringResolver
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.io.StringReader
@@ -32,6 +33,8 @@ import org.xml.sax.InputSource
  * 负责将所有数据导出为CSV文件，以及从CSV文件导入数据
  */
 class DataExportImportManager(private val context: Context) {
+
+    private val strings by lazy { AppLocaleStringResolver(context) }
 
     /**
      * 导出数据项
@@ -87,7 +90,7 @@ class DataExportImportManager(private val context: Context) {
             var headerIndexMap: Map<String, Int>? = null
             
             val inputStream = context.contentResolver.openInputStream(inputUri)
-                ?: return@withContext Result.failure(Exception("无法读取文件，请检查文件是否存在"))
+                ?: return@withContext Result.failure(Exception(strings.get(R.string.import_csv_file_unreadable)))
             
             inputStream.use { input ->
                 // 尝试UTF-8，如果失败则尝试GBK
@@ -101,7 +104,7 @@ class DataExportImportManager(private val context: Context) {
                 reader.use { 
                     var firstLine = readCsvRecord(reader)
                     if (firstLine == null) {
-                        return@withContext Result.failure(Exception("文件为空"))
+                        return@withContext Result.failure(Exception(strings.get(R.string.import_csv_file_empty)))
                     }
                     
                     // 跳过BOM标记（如果存在）
@@ -202,13 +205,20 @@ class DataExportImportManager(private val context: Context) {
             }
 
             if (items.isEmpty()) {
-                Result.failure(Exception(context.getString(R.string.import_csv_no_data_found)))
+                Result.failure(Exception(strings.get(R.string.import_csv_no_data_found)))
             } else {
                 Result.success(items)
             }
         } catch (e: Exception) {
             android.util.Log.e("DataImport", "导入异常", e)
-            Result.failure(Exception("导入失败：${e.message ?: "文件格式错误"}"))
+            Result.failure(
+                Exception(
+                    strings.get(
+                        R.string.import_data_failed_with_reason,
+                        e.message ?: strings.get(R.string.import_csv_invalid_format)
+                    )
+                )
+            )
         }
     }
 

--- a/Monica for Android/app/src/main/java/takagi/ru/monica/util/DataExportImportManager.kt
+++ b/Monica for Android/app/src/main/java/takagi/ru/monica/util/DataExportImportManager.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
+import takagi.ru.monica.R
 import takagi.ru.monica.data.model.BankCardData
 import takagi.ru.monica.data.model.NoteData
 import takagi.ru.monica.data.model.SecureCustomField
@@ -201,7 +202,7 @@ class DataExportImportManager(private val context: Context) {
             }
 
             if (items.isEmpty()) {
-                Result.failure(Exception("未能导入任何数据，请检查文件格式"))
+                Result.failure(Exception(context.getString(R.string.import_csv_no_data_found)))
             } else {
                 Result.success(items)
             }

--- a/Monica for Android/app/src/main/res/values-de/strings.xml
+++ b/Monica for Android/app/src/main/res/values-de/strings.xml
@@ -3533,6 +3533,10 @@
     <string name="import_type_stratum_title">Stratum-Auth</string>
     <string name="import_type_stratum_desc">Stratum/AuthPro-Backup importieren (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">.stratum / .txt / auswählen .html-Datei</string>
+    <string name="import_csv_no_data_found">Es konnten keine Daten importiert werden. Bitte prüfe das Dateiformat.</string>
+    <string name="import_csv_file_unreadable">Die Datei konnte nicht gelesen werden. Prüfe, ob sie noch vorhanden ist.</string>
+    <string name="import_csv_file_empty">Die Datei ist leer.</string>
+    <string name="import_csv_invalid_format">Ungültiges Dateiformat</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Steam-Token aus maFile importieren</string>
     <string name="import_type_steam_file_hint">.maFile-Datei auswählen</string>

--- a/Monica for Android/app/src/main/res/values-es/strings.xml
+++ b/Monica for Android/app/src/main/res/values-es/strings.xml
@@ -3533,6 +3533,10 @@
     <string name="import_type_stratum_title">Autenticación de estrato</string>
     <string name="import_type_stratum_desc">Importar copia de seguridad Stratum/AuthPro (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">Seleccione el archivo .stratum/.txt/.html</string>
+    <string name="import_csv_no_data_found">No se pudieron importar datos. Comprueba el formato del archivo.</string>
+    <string name="import_csv_file_unreadable">No se pudo leer el archivo. Comprueba que todavía existe.</string>
+    <string name="import_csv_file_empty">El archivo está vacío.</string>
+    <string name="import_csv_invalid_format">Formato de archivo no válido</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Importar token Steam desde maFile</string>
     <string name="import_type_steam_file_hint">Seleccione el archivo .maFile</string>

--- a/Monica for Android/app/src/main/res/values-ja/strings.xml
+++ b/Monica for Android/app/src/main/res/values-ja/strings.xml
@@ -1722,6 +1722,10 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">Stratum/AuthPro バックアップ（.stratum/.txt/.html）をインポート</string>
     <string name="import_type_stratum_file_hint">.stratum / .txt / .html ファイルを選択</string>
+    <string name="import_csv_no_data_found">データをインポートできませんでした。ファイル形式を確認してください。</string>
+    <string name="import_csv_file_unreadable">ファイルを読み取れませんでした。ファイルが存在するか確認してください。</string>
+    <string name="import_csv_file_empty">ファイルが空です。</string>
+    <string name="import_csv_invalid_format">ファイル形式が正しくありません</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">maFile から Steam トークンをインポート</string>
     <string name="import_type_steam_file_hint">.maFile ファイルを選択</string>

--- a/Monica for Android/app/src/main/res/values-ko/strings.xml
+++ b/Monica for Android/app/src/main/res/values-ko/strings.xml
@@ -3533,6 +3533,10 @@
     <string name="import_type_stratum_title">Stratum 인증</string>
     <string name="import_type_stratum_desc">Stratum/AuthPro 백업 가져오기(.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">.stratum / .txt / 선택 .html 파일</string>
+    <string name="import_csv_no_data_found">데이터를 가져오지 못했습니다. 파일 형식을 확인하세요.</string>
+    <string name="import_csv_file_unreadable">파일을 읽지 못했습니다. 파일이 아직 있는지 확인하세요.</string>
+    <string name="import_csv_file_empty">파일이 비어 있습니다.</string>
+    <string name="import_csv_invalid_format">잘못된 파일 형식</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">maFile에서 Steam 토큰 가져오기</string>
     <string name="import_type_steam_file_hint">.maFile 파일 선택</string>

--- a/Monica for Android/app/src/main/res/values-ru/strings.xml
+++ b/Monica for Android/app/src/main/res/values-ru/strings.xml
@@ -2947,6 +2947,7 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">Импорт Stratum/AuthPro (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">Выберите .stratum / .txt / .html</string>
+    <string name="import_csv_no_data_found">Не удалось импортировать данные. Проверьте формат файла.</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Импорт токена Steam из maFile</string>
     <string name="import_type_steam_file_hint">Выберите .maFile</string>

--- a/Monica for Android/app/src/main/res/values-ru/strings.xml
+++ b/Monica for Android/app/src/main/res/values-ru/strings.xml
@@ -2947,6 +2947,9 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">Импорт Stratum/AuthPro (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">Выберите .stratum / .txt / .html</string>
+    <string name="import_csv_file_unreadable">Не удалось прочитать файл. Убедитесь, что он существует.</string>
+    <string name="import_csv_file_empty">Файл пуст.</string>
+    <string name="import_csv_invalid_format">Неверный формат файла</string>
     <string name="import_csv_no_data_found">Не удалось импортировать данные. Проверьте формат файла.</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Импорт токена Steam из maFile</string>

--- a/Monica for Android/app/src/main/res/values-vi/strings.xml
+++ b/Monica for Android/app/src/main/res/values-vi/strings.xml
@@ -1741,6 +1741,10 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">Nhap ban sao luu Stratum/AuthPro (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">Chon tep .stratum / .txt / .html</string>
+    <string name="import_csv_no_data_found">Không thể nhập dữ liệu. Vui lòng kiểm tra định dạng tệp.</string>
+    <string name="import_csv_file_unreadable">Không thể đọc tệp. Hãy kiểm tra xem tệp còn tồn tại không.</string>
+    <string name="import_csv_file_empty">Tệp trống.</string>
+    <string name="import_csv_invalid_format">Định dạng tệp không hợp lệ</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Nhap token Steam tu tep maFile</string>
     <string name="import_type_steam_file_hint">Chon tep .maFile</string>

--- a/Monica for Android/app/src/main/res/values-zh/strings.xml
+++ b/Monica for Android/app/src/main/res/values-zh/strings.xml
@@ -3407,6 +3407,9 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">导入 Stratum/AuthPro 备份（.stratum/.txt/.html）</string>
     <string name="import_type_stratum_file_hint">选择 .stratum / .txt / .html 文件</string>
+    <string name="import_csv_file_unreadable">无法读取文件，请检查文件是否存在</string>
+    <string name="import_csv_file_empty">文件为空</string>
+    <string name="import_csv_invalid_format">文件格式错误</string>
     <string name="import_csv_no_data_found">未能导入任何数据，请检查文件格式</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">导入 Steam 令牌的 maFile 文件</string>

--- a/Monica for Android/app/src/main/res/values-zh/strings.xml
+++ b/Monica for Android/app/src/main/res/values-zh/strings.xml
@@ -3407,6 +3407,7 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">导入 Stratum/AuthPro 备份（.stratum/.txt/.html）</string>
     <string name="import_type_stratum_file_hint">选择 .stratum / .txt / .html 文件</string>
+    <string name="import_csv_no_data_found">未能导入任何数据，请检查文件格式</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">导入 Steam 令牌的 maFile 文件</string>
     <string name="import_type_steam_file_hint">选择 .maFile 文件</string>

--- a/Monica for Android/app/src/main/res/values/strings.xml
+++ b/Monica for Android/app/src/main/res/values/strings.xml
@@ -3593,6 +3593,9 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">Import Stratum/AuthPro backup (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">Select .stratum / .txt / .html file</string>
+    <string name="import_csv_file_unreadable">Could not read the file. Check that it still exists.</string>
+    <string name="import_csv_file_empty">The file is empty.</string>
+    <string name="import_csv_invalid_format">Invalid file format</string>
     <string name="import_csv_no_data_found">No data could be imported. Please check the file format.</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Import Steam token from maFile</string>

--- a/Monica for Android/app/src/main/res/values/strings.xml
+++ b/Monica for Android/app/src/main/res/values/strings.xml
@@ -3593,6 +3593,7 @@
     <string name="import_type_stratum_title">Stratum Auth</string>
     <string name="import_type_stratum_desc">Import Stratum/AuthPro backup (.stratum/.txt/.html)</string>
     <string name="import_type_stratum_file_hint">Select .stratum / .txt / .html file</string>
+    <string name="import_csv_no_data_found">No data could be imported. Please check the file format.</string>
     <string name="import_type_steam_title">Steam Guard</string>
     <string name="import_type_steam_desc">Import Steam token from maFile</string>
     <string name="import_type_steam_file_hint">Select .maFile file</string>


### PR DESCRIPTION
- CSV import failure message was a raw Chinese literal thrown from Exception(...), shown to users regardless of locale. Moved it to a string resource (EN/RU/ZH).
- ImportDataScreen and DedupEngineScreen bottom action bars had the same missing-navigationBarsPadding() issue as the quick-setup wizard fixed earlier: on-screen nav buttons covered the bottom hint text / merge button.
